### PR TITLE
Add hrule & vrule to plot2d

### DIFF
--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -242,6 +242,28 @@ For example, to plot an estimated density of the triangle distribution:
                                          #:label "Est. density")))]
 }
 
+@defproc[(hline [y real?]
+                [x-min (or/c rational? #f) #f] [x-max (or/c rational? #f) #f]
+                [#:color color plot-color/c (line-color)]
+                [#:width width (>=/c 0) (line-width)]
+                [#:style style plot-pen-style/c (line-style)]
+                [#:label label (or/c string? #f) #f]
+                ) renderer2d?]{
+Draws a horizontal line at @italic{y}.
+By default, the line spans the entire plot area width.
+}
+
+@defproc[(vline [x real?]
+                [y-min (or/c rational? #f) #f] [y-max (or/c rational? #f) #f]
+                [#:color color plot-color/c (line-color)]
+                [#:width width (>=/c 0) (line-width)]
+                [#:style style plot-pen-style/c (line-style)]
+                [#:label label (or/c string? #f) #f]
+                ) renderer2d?]{
+Draws a vertical line at @italic{x}.
+By default, the line spans the entire plot area height.
+}
+
 @section{2D Interval Renderers}
 
 These renderers each correspond with a line renderer, and graph the area between two lines.

--- a/plot-lib/plot/no-gui.rkt
+++ b/plot-lib/plot/no-gui.rkt
@@ -47,6 +47,8 @@
  lines
  parametric
  polar
+ hrule
+ vrule
  function
  inverse
  density)

--- a/plot-lib/plot/private/common/draw-attribs.rkt
+++ b/plot-lib/plot/private/common/draw-attribs.rkt
@@ -46,10 +46,10 @@
 (define (make-color% r g b)
   (make-color r g b))
 
-(: make-pen% (-> Byte Byte Byte Nonnegative-Real Pen-Style (Instance Pen%)))
+(: make-pen% (-> Byte Byte Byte Nonnegative-Real Pen-Style Pen-Cap-Style (Instance Pen%)))
 ;; Returns an immutable instance of pen%. Same reasoning as for make-color%.
-(define (make-pen% r g b w s)
-  (make-pen #:color (make-color% r g b) #:width w #:style s))
+(define (make-pen% r g b w s c)
+  (make-pen #:color (make-color% r g b) #:width w #:style s #:cap c))
 
 (: make-brush% (-> Byte Byte Byte Brush-Style (Instance Brush%)))
 ;; Returns an immutable instance of brush%. Same reasoning as for make-color%.

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -96,7 +96,7 @@
                [dc-y-size Nonnegative-Real])
    [restore-drawing-params (-> Void)]
    [reset-drawing-params (->* [] [Boolean] Void)]
-   [set-pen (-> Plot-Color Nonnegative-Real Plot-Pen-Style Void)]
+   [set-pen (->* [Plot-Color Nonnegative-Real Plot-Pen-Style] [Pen-Cap-Style] Void)]
    [set-major-pen (->* [] [Plot-Pen-Style] Void)]
    [set-minor-pen (->* [] [Plot-Pen-Style] Void)]
    [set-brush (-> Plot-Color Plot-Brush-Style Void)]


### PR DESCRIPTION
EDIT: adds `hrule` and `vrule` for drawing straight lines (with a square pen).

Demo:
```
#lang racket

(require plot/pict pict racket/class)

(define (make-plot)
  (parameterize ([line-width (* 3 (line-width))])
    (plot-pict
     (list
      (hrule 4 0 1 #:color 'purple #:style 'short-dash #:label "h")
      (hrule 1 #:color 'blue #:style 'long-dash #:label "H")
      (vrule 2 0 1 #:color 'green #:style 'short-dash #:label "v")
      (vrule 1 #:color 'red #:style 'long-dash #:label "V")
      )
     #:x-min 0
     #:x-max 5
     #:y-min 0
     #:y-max 5
     #:width 200
     #:height 200
     #:legend-anchor 'top-right
     )))

(send (pict->bitmap (make-plot)) save-file "rule.png" 'png)
```

![out](https://cloud.githubusercontent.com/assets/1731829/8884539/679e1902-3225-11e5-930d-a226b9d31cb0.png)


