### PR TITLE
Add #:samples to type for area-histogram

### DIFF
--- a/plot-lib/plot/private/plot2d/rectangle.rkt
+++ b/plot-lib/plot/private/plot2d/rectangle.rkt
@@ -85,6 +85,7 @@
     (->* [(-> Real Real) (Sequenceof Real)]
          [#:x-min (U Real #f) #:x-max (U Real #f)
           #:y-min (U Real #f) #:y-max (U Real #f)
+          #:samples Positive-Integer
           #:color Plot-Color
           #:style Plot-Brush-Style
           #:line-color Plot-Color
@@ -129,7 +130,9 @@
                                        [x2  (in-list (rest bin-bounds))])
               (define x-size (- x2 x1))
               (define ys (map f xs))
-              (/ (apply + ys) (length xs))))
+              (define num-xs (length xs))
+              ;; Some bins may not have samples, even if (< (length bin-bounds) samples)
+              (if (zero? num-xs) 0 (/ (apply + ys) (length xs)))))
           (rectangles (map (λ ([x-ivl : ivl] [h : Real]) (vector x-ivl (ivl 0 h)))
                            (bounds->intervals bin-bounds)
                            heights)

--- a/plot-test/plot/tests/plot2d-tests.rkt
+++ b/plot-test/plot/tests/plot2d-tests.rkt
@@ -253,6 +253,11 @@
              (function f -4 4))))
 
 (time
+ ;; Intentionally using fewer samples than bins
+ (plot (list (area-histogram sqr (map (λ (x) (* (sqrt x) (sqrt 8))) (linear-seq 0 8 10)) #:samples 2)
+             (function sqr 0 8 #:samples 2))))
+
+(time
  (plot (list (area-histogram sqr (map (λ (x) (* (sqrt x) (sqrt 8))) (linear-seq 0 8 10)))
              (function sqr 0 8))))
 


### PR DESCRIPTION
The `#:samples` argument was implemented & documented, but not part of the type.

PR also adds a check for empty bins when making the `area-histogram`.
Empty bins are likely to happen `(- samples (length bin-bounds))` is small.

For example (using the `bin-samples` function from `plot-lib/plot/private/common/utils.rkt`):
```
(define bin-bounds '(0 9 10))
(define samples 4)
(define x* (linear-seq 0 10 samples
                       #:start? #f #:end? #f))

(displayln (bin-samples bin-bounds x*))
;; No samples fall in range [9, 10)
;; ((5/4 15/4 25/4 35/4) ())
```

Before this PR, `area-histogram` would raise a `division by zero` error