### PR TITLE
doc: add the #:alpha argument for hrule and vrule

### DIFF
--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -285,6 +285,7 @@ For example, to plot an estimated density of the triangle distribution:
                 [#:color color plot-color/c (line-color)]
                 [#:width width (>=/c 0) (line-width)]
                 [#:style style plot-pen-style/c (line-style)]
+                [#:alpha alpha (real-in 0 1) (line-alpha)]
                 [#:label label (or/c string? #f) #f]
                 ) renderer2d?]{
 Draws a horizontal line at @italic{y}.
@@ -296,6 +297,7 @@ By default, the line spans the entire plot area width.
                 [#:color color plot-color/c (line-color)]
                 [#:width width (>=/c 0) (line-width)]
                 [#:style style plot-pen-style/c (line-style)]
+                [#:alpha alpha (real-in 0 1) (line-alpha)]
                 [#:label label (or/c string? #f) #f]
                 ) renderer2d?]{
 Draws a vertical line at @italic{x}.

--- a/plot-test/plot/tests/plot2d-tests.rkt
+++ b/plot-test/plot/tests/plot2d-tests.rkt
@@ -491,3 +491,14 @@
                (function f 1 14 #:color 4)
                (point-label (vector 0 1) "y → 1 as x → 0" #:anchor 'bottom-right))
          #:y-max 1.2)))
+
+(time ;; check `hrule` and `vrule` arguments
+  (plot
+    (list (hrule -1)
+          (hrule 0 0)
+          (hrule 1 0 1 #:color 1 #:width 3 #:style 'long-dash #:alpha 0.6 #:label "H")
+          (vrule -1)
+          (vrule 0 0)
+          (vrule 1 0 1 #:color 2 #:width 3 #:style 'long-dash #:alpha 0.6 #:label "V"))
+    #:x-min -2 #:x-max 2
+    #:y-min -2 #:y-max 2))


### PR DESCRIPTION
Just found myself wanting a partly-transparent vertical line.
`#:alpha` wasn't in the docs. Bummer. Let's see about adding it.
Lo and behold 'twas already implemented.

I thought about adding a test, but wasn't sure if I could just append to `plot2d-tests.rkt`