### PR TITLE
Fix typo, 'cirlce2' => 'circle2'

### DIFF
--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -52,7 +52,7 @@
       [(18)  (values 'full5star size)]
       [(19)  (values 'square size)]
       [(20 circle1)  (values 'circle (* 3/6 size))]
-      [(21 cirlce2)  (values 'circle (* 4/6 size))]
+      [(21 circle2)  (values 'circle (* 4/6 size))]
       [(22 circle3)  (values 'circle (* 5/6 size))]
       [(23 circle4)  (values 'circle size)]
       [(24 circle5)  (values 'circle (* 8/6 size))]

--- a/plot-test/plot/tests/PRs/24.rkt
+++ b/plot-test/plot/tests/PRs/24.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+(require plot plot/utils)
+
+;; Plot all `known-point-symbols`.
+;; This test succeeds when it terminates.
+
+(define NUM-ROWS 3)
+(define YOFFSET 4)
+
+(parameterize ([plot-x-axis? #f]
+               [plot-y-axis? #f]
+               [plot-x-far-axis? #f]
+               [plot-y-far-axis? #f]
+               [plot-decorations? #f])
+  (plot
+    (for/list ([s (in-list known-point-symbols)]
+               [i (in-naturals)])
+      (points (list (list (modulo i NUM-ROWS) (- (* YOFFSET (quotient i NUM-ROWS)))))
+        #:sym s
+        #:size 10))
+    #:x-min -1
+    #:x-max NUM-ROWS
+    #:y-min (- (+ 1 (* YOFFSET (quotient (length known-point-symbols) NUM-ROWS))))
+    #:y-max 1))


### PR DESCRIPTION
Fix a typo in a case statement clause, also add a test that plots all `known-point-symbols`

Closes #23 