### PR TITLE
add a candlestick point plot

### DIFF
--- a/plot-doc/plot/scribblings/params.scrbl
+++ b/plot-doc/plot/scribblings/params.scrbl
@@ -250,6 +250,22 @@ The default pen color, pen width, pen style, scaling factor, and opacity used by
 The default width, pen color/width/style, and opacity used by @racket[error-bars].
 }
 
+@section{Candlesticks}
+
+@deftogether[((defparam candlestick-width width (>=/c 0) #:value 6)
+              (defparam candlestick-up-color color plot-color/c #:value 2)
+              (defparam candlestick-down-color color plot-color/c #:value 1)
+              (defparam candlestick-line-width pen-width (>=/c 0) #:value 1)
+              (defparam candlestick-line-style pen-style plot-pen-style/c #:value 'solid)
+              (defparam candlestick-alpha alpha (real-in 0 1) #:value 2/3))]{
+The default width, pen color/width/style, and opacity used by @racket[candlesticks]. Both the up (a candle whose 
+open value is lower than its close value) color and the down (a candle whose open value is higher than its close 
+value) color can be specified independently. The width parameter will be important to specify if your x-axis is 
+in units like days, weeks, or months. Because dates are actually represented as seconds from an epoch, your 
+width should take that into consideration. For example, a width of 86400 may be useful for x-axis values in days 
+as there are 86400 seconds in a day. This candle will be exactly one day in width.
+}
+
 @section{Contours and Contour Intervals}
 
 @deftogether[(

--- a/plot-doc/plot/scribblings/params.scrbl
+++ b/plot-doc/plot/scribblings/params.scrbl
@@ -252,7 +252,7 @@ The default width, pen color/width/style, and opacity used by @racket[error-bars
 
 @section{Candlesticks}
 
-@deftogether[((defparam candlestick-width width (>=/c 0) #:value 6)
+@deftogether[((defparam candlestick-width width (>=/c 0) #:value 1)
               (defparam candlestick-up-color color plot-color/c #:value 2)
               (defparam candlestick-down-color color plot-color/c #:value 1)
               (defparam candlestick-line-width pen-width (>=/c 0) #:value 1)

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -175,10 +175,9 @@ Returns a renderer that draws candlesticks. This is most common when plotting hi
 instruments. The first element in each vector of @(racket candles) comprises the x-axis coordinate; the second, third, 
 fourth, and fifth elements in each vector comprise the open, high, low, and close, respectively, of the y-axis coordinates.
 @interaction[#:eval plot-eval
-                    (plot (list (function sqr 1 7)
-                                (candlesticks (list (vector 2 4 12 4 8)
-                                                  (vector 4 16 20 8 12)
-                                                  (vector 6 24 36 10 24)))))]
+                    (plot (list (candlesticks (list (vector 2 4 12 4 8)
+                                                    (vector 4 16 20 8 12)
+                                                    (vector 6 24 36 10 24)))))]
 }
 
 @section{2D Line Renderers}

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -160,6 +160,27 @@ The first and second element in each vector in @(racket bars) comprise the coord
                                                   (vector 6 36 10)))))]
 }
 
+@defproc[(candlesticks
+          [candles (sequence/c (sequence/c #:min-count 5 real?))]
+          [#:x-min x-min (or/c rational? #f) #f] [#:x-max x-max (or/c rational? #f) #f]
+          [#:y-min y-min (or/c rational? #f) #f] [#:y-max y-max (or/c rational? #f) #f]
+          [#:up-color up-color plot-color/c (candlestick-up-color)]
+          [#:down-color down-color plot-color/c (candlestick-down-color)]
+          [#:line-width line-width (>=/c 0) (candlestick-line-width)]
+          [#:line-style line-style plot-pen-style/c (candlestick-line-style)]
+          [#:width width (>=/c 0) (candlestick-width)]
+          [#:alpha alpha (real-in 0 1) (candlestick-alpha)]
+          ) renderer2d?]{
+Returns a renderer that draws candlesticks. This is most common when plotting historical prices for financial 
+instruments. The first element in each vector of @(racket candles) comprises the x-axis coordinate; the second, third, 
+fourth, and fifth elements in each vector comprise the open, high, low, and close, respectively, of the y-axis coordinates.
+@interaction[#:eval plot-eval
+                    (plot (list (function sqr 1 7)
+                                (candlesticks (list (vector 2 4 12 4 8)
+                                                  (vector 4 16 20 8 12)
+                                                  (vector 6 24 36 10 24)))))]
+}
+
 @section{2D Line Renderers}
 
 @defproc[(function [f (real? . -> . real?)]

--- a/plot-lib/plot/no-gui.rkt
+++ b/plot-lib/plot/no-gui.rkt
@@ -40,7 +40,8 @@
 (provide
  points
  vector-field
- error-bars)
+ error-bars
+ candlesticks)
 
 (require "private/plot2d/line.rkt")
 (provide

--- a/plot-lib/plot/private/common/parameters.rkt
+++ b/plot-lib/plot/private/common/parameters.rkt
@@ -205,6 +205,15 @@
 (defparam error-bar-line-style Plot-Pen-Style 'solid)
 (defparam2 error-bar-alpha Real Nonnegative-Real 2/3 (unit-ivl 'error-bar-alpha))
 
+;; Candlesticks
+
+(defparam2 candlestick-width Real Nonnegative-Real 6 (nonnegative-rational 'candlestick-width))
+(defparam candlestick-up-color Plot-Color 2)
+(defparam candlestick-down-color Plot-Color 1)
+(defparam2 candlestick-line-width Real Nonnegative-Real 1 (nonnegative-rational 'candlestick-line-width))
+(defparam candlestick-line-style Plot-Pen-Style 'solid)
+(defparam2 candlestick-alpha Real Nonnegative-Real 2/3 (unit-ivl 'candlestick-alpha))
+
 ;; Contours
 
 (:: default-contour-colors (-> (Listof Real) (Listof Plot-Color)))

--- a/plot-lib/plot/private/common/parameters.rkt
+++ b/plot-lib/plot/private/common/parameters.rkt
@@ -207,7 +207,7 @@
 
 ;; Candlesticks
 
-(defparam2 candlestick-width Real Nonnegative-Real 6 (nonnegative-rational 'candlestick-width))
+(defparam2 candlestick-width Real Nonnegative-Real 1 (nonnegative-rational 'candlestick-width))
 (defparam candlestick-up-color Plot-Color 2)
 (defparam candlestick-down-color Plot-Color 1)
 (defparam2 candlestick-line-width Real Nonnegative-Real 1 (nonnegative-rational 'candlestick-line-width))

--- a/plot-lib/plot/private/plot2d/point.rkt
+++ b/plot-lib/plot/private/plot2d/point.rkt
@@ -264,7 +264,6 @@
   (send area put-alpha alpha)
   (send area put-pen up-color line-width line-style)
   (for ([x  (in-list xs)] [open  (in-list opens)] [high  (in-list highs)] [low  (in-list lows)] [close  (in-list closes)])
-    ;(when (rect-contains? clip-rect (vector x (/ (+ high low) 2)))
       (define v1 (vector x open))
       (define v2 (vector x high))
       (define v3 (vector x low))
@@ -279,7 +278,7 @@
                   (send area put-line v2 v4)
                   (send area put-line v1 v3)
                   (send area put-brush up-color 'solid)
-                  (send area put-rect r1)]));)
+                  (send area put-rect r1)]))
   empty)
 
 (:: candlesticks
@@ -296,8 +295,8 @@
 (define (candlesticks candles
                       #:x-min [x-min #f] #:x-max [x-max #f]
                       #:y-min [y-min #f] #:y-max [y-max #f]
-                      #:up-color [up-color candlestick-up-color]
-                      #:down-color [down-color candlestick-down-color]
+                      #:up-color [up-color (candlestick-up-color)]
+                      #:down-color [down-color (candlestick-down-color)]
                       #:line-width [line-width (candlestick-line-width)]
                       #:line-style [line-style (candlestick-line-style)]
                       #:width [width (candlestick-width)]
@@ -322,8 +321,8 @@
                                           #{closes : (Listof Real)})
                                   ...)
                 candles)
-              (let ([x-min  (if x-min x-min (apply min* xs))]
-                    [x-max  (if x-max x-max (apply max* xs))]
+              (let ([x-min  (if x-min x-min (- (apply min* xs) width))]
+                    [x-max  (if x-max x-max (+ (apply max* xs) width))]
                     [y-min  (if y-min y-min (apply min* lows))]
                     [y-max  (if y-max y-max (apply max* highs))])
                 (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -143,6 +143,12 @@
  error-bar-line-width
  error-bar-line-style
  error-bar-alpha
+ candlestick-width
+ candlestick-up-color
+ candlestick-down-color
+ candlestick-line-width
+ candlestick-line-style
+ candlestick-alpha
  contour-samples
  contour-levels
  contour-colors


### PR DESCRIPTION
add a candlestick point plot that will show open, high, low, and close values commonly used for financial charts. include default parameters and documentation.

I apologize, but I have been unable to get raco to build, test, and display meaningful scribble documents for this PR. I can try to get that working, but if it's easier for someone else to kick off some continuous integration and see that things are okay, that would be helpful. I hope this contribution is welcome.