### PR TITLE
Provide plot3d interface unsafely to avoid excessive overhead.

### DIFF
--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -12,11 +12,12 @@
          plot/private/no-gui/plot3d
          plot/private/no-gui/plot3d-utils
          plot/private/no-gui/utils
-         "lazy-snip-typed.rkt")
+         "lazy-snip-typed.rkt"
+         typed/racket/unsafe)
 
-(provide plot3d-snip
-         plot3d-frame
-         plot3d)
+(unsafe-provide plot3d-snip
+                plot3d-frame
+                plot3d)
 
 ;; ===================================================================================================
 ;; Plot to a snip

--- a/plot-lib/plot/private/no-gui/plot3d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d-utils.rkt
@@ -13,14 +13,16 @@
 
 (provide (all-defined-out))
 
-(: get-renderer-list (-> (Treeof (U renderer3d nonrenderer)) (Listof renderer3d)))
+(: get-renderer-list (-> Any (Listof renderer3d)))
 (define (get-renderer-list renderer-tree)
   (cond [(list? renderer-tree)  (append* (map get-renderer-list renderer-tree))]
         [(nonrenderer? renderer-tree)
          (match-define (nonrenderer bounds-rect bounds-fun ticks-fun) renderer-tree)
          (list (renderer3d bounds-rect bounds-fun ticks-fun #f))]
+        [(renderer3d? renderer-tree)
+         (list renderer-tree)]
         [else
-         (list renderer-tree)]))
+         (raise-argument-error 'get-renderer-list "(or/c list? nonrenderer? renderer3d?)" renderer-tree)]))
 
 (: get-bounds-rect (-> (Listof renderer3d)
                        (U #f Real) (U #f Real)


### PR DESCRIPTION
These three provided functions don't take any higher-order arguments and their
results are actually implemented in untyped code, so there should not be a
risk of segfaults, plus they check their first-order arguments. Additionally,
the result contracts have not been checked in past releases due to a bug in
contract generation, increasing confidence that this is safe.

Fixes racket/gui#86. Related to racket/typed-racket#599.

I hope to merge this for 6.12 to fix the regression noted in
racket/gui#86.