### PR TITLE
plot3d regression tests

### DIFF
--- a/plot-doc/plot/scribblings/contracts.scrbl
+++ b/plot-doc/plot/scribblings/contracts.scrbl
@@ -120,6 +120,11 @@ The contract for the @(racket #:sym) arguments in @(racket points) and @(racket 
 A list containing the symbols that are valid @(racket points) symbols.
 }
 
+@defthing[plot-file-format/c contract? #:value (or/c 'auto 'png 'jpeg 'xmb 'xpm 'bmp 'ps 'pdf 'svg)]{
+  A contract for an argument that describes an image file format.
+}
+
+
 @section{Appearance Argument List Contracts}
 
 @defproc[(maybe-function/c [in-contract contract?] [out-contract contract?])

--- a/plot-doc/plot/scribblings/plotting.scrbl
+++ b/plot-doc/plot/scribblings/plotting.scrbl
@@ -30,7 +30,7 @@ Each 3D plotting procedure behaves the same way as its corresponding 2D procedur
                [#:y-label y-label (or/c string? #f) (plot-y-label)]
                [#:legend-anchor legend-anchor anchor/c (plot-legend-anchor)]
                [#:out-file out-file (or/c path-string? output-port? #f) #f]
-               [#:out-kind out-kind (one-of/c 'auto 'png 'jpeg 'xmb 'xpm 'bmp 'ps 'pdf 'svg) 'auto]
+               [#:out-kind out-kind plot-file-format/c 'auto]
                ) (or/c (is-a?/c snip%) void?)]{
 Plots a 2D renderer or list of renderers (or more generally, a tree of renderers), as returned by @(racket points), @(racket function), @(racket contours), @(racket discrete-histogram), and others.
 
@@ -76,7 +76,7 @@ The @(racket #:lncolor) keyword argument is also accepted for backward compatibi
                  [#:z-label z-label (or/c string? #f) (plot-z-label)]
                  [#:legend-anchor legend-anchor anchor/c (plot-legend-anchor)]
                  [#:out-file out-file (or/c path-string? output-port? #f) #f]
-                 [#:out-kind out-kind (one-of/c 'auto 'png 'jpeg 'xmb 'xpm 'bmp 'ps 'pdf 'svg) 'auto]
+                 [#:out-kind out-kind plot-file-format/c 'auto]
                  ) (or/c (is-a?/c snip%) void?)]{
 Plots a 3D renderer or list of renderers (or more generally, a tree of renderers), as returned by @(racket points3d), @(racket parametric3d), @(racket surface3d), @(racket isosurface3d), and others.
 
@@ -119,12 +119,12 @@ for more details.
 
 @defproc[(plot-file [renderer-tree (treeof (or/c renderer2d? nonrenderer?))]
                     [output (or/c path-string? output-port?)]
-                    [kind (one-of/c 'auto 'png 'jpeg 'xmb 'xpm 'bmp 'ps 'pdf 'svg) 'auto]
+                    [kind plot-file-format/c 'auto]
                     [#:<plot-keyword> <plot-keyword> <plot-keyword-contract>] ...)
          void?]
 @defproc[(plot3d-file [renderer-tree (treeof (or/c renderer3d? nonrenderer?))]
                       [output (or/c path-string? output-port?)]
-                      [kind (one-of/c 'auto 'png 'jpeg 'xmb 'xpm 'bmp 'ps 'pdf 'svg) 'auto]
+                      [kind plot-file-format/c 'auto]
                       [#:<plot3d-keyword> <plot3d-keyword> <plot3d-keyword-contract>] ...)
          void?]
 @defproc[(plot-pict [<plot-argument> <plot-argument-contract>] ...)

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -19,6 +19,11 @@
                 plot-frame
                 plot)
 
+(require/typed plot/utils
+  (anchor/c (-> Any Boolean))
+  (plot-color/c (-> Any Boolean))
+  (plot-file-format/c (-> Any Boolean)))
+
 ;; ===================================================================================================
 ;; Plot to a snip
 
@@ -115,6 +120,13 @@
      ;; make-snip will be called in a separate thread, make sure the
      ;; parameters have the correct values in that thread as well.
      (define saved-plot-parameters (plot-parameters))
+     (cond ;; check arguments because function is provided unsafely
+      [(not (and (integer? width) (positive? width))) (fail/kw "positive integer" '#:width width)]
+      [(not (and (integer? height) (positive? height))) (fail/kw "positive integer" '#:height height)]
+      [(and title (not (string? title))) (fail/kw "#f or string" '#:title title)]
+      [(and x-label (not (string? x-label))) (fail/kw "#f or string" '#:x-label x-label)]
+      [(and y-label (not (string? y-label))) (fail/kw "#f or string" '#:y-label y-label)]
+      [(not (anchor/c legend-anchor)) (fail/kw "anchor/c" '#:legend-anchor legend-anchor)])
      (: make-snip (-> Positive-Integer Positive-Integer (Instance Snip%)))
      (define (make-snip width height)
        (parameterize/group ([plot-parameters  saved-plot-parameters])
@@ -171,6 +183,13 @@
     [(and y-min (not (rational? y-min)))  (fail/kw "#f or rational" '#:y-min y-min)]
     [(and y-max (not (rational? y-max)))  (fail/kw "#f or rational" '#:y-max y-max)]
     [else
+     (cond ;; check arguments because function is provided unsafely
+      [(and out-kind (not (plot-file-format/c out-kind)))
+       (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
+      [(and fgcolor (not (plot-color/c fgcolor)))
+       (fail/kw "plot-color/c" '#:fgcolor fgcolor)]
+      [(and bgcolor (not (plot-color/c bgcolor)))
+       (fail/kw "plot-color/c" '#:bgcolor bgcolor)])
      (parameterize ([plot-foreground  (if fgcolor fgcolor (plot-foreground))]
                     [plot-background  (if bgcolor bgcolor (plot-background))])
        (when out-file

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -20,6 +20,11 @@
                 plot3d-frame
                 plot3d)
 
+(require/typed plot/utils
+  (anchor/c (-> Any Boolean))
+  (plot-color/c (-> Any Boolean))
+  (plot-file-format/c (-> Any Boolean)))
+
 ;; ===================================================================================================
 ;; Plot to a snip
 
@@ -58,6 +63,8 @@
     [(and y-max (not (rational? y-max)))  (fail/kw "#f or rational" '#:y-max y-max)]
     [(and z-min (not (rational? z-min)))  (fail/kw "#f or rational" '#:z-min z-min)]
     [(and z-max (not (rational? z-max)))  (fail/kw "#f or rational" '#:z-max z-max)])
+  (cond ;; because this function is exported via `unsafe-provide`
+    [(not (anchor/c legend-anchor))        (fail/kw "anchor/c" '#:legend-anchor legend-anchor)])
   
   (parameterize ([plot-title          title]
                  [plot-x-label        x-label]
@@ -197,8 +204,8 @@
                 #:z-min [z-min #f] #:z-max [z-max #f]
                 #:width [width (plot-width)]
                 #:height [height (plot-height)]
-                #:angle [angle (plot3d-angle)]
-                #:altitude [altitude (plot3d-altitude)]
+                #:angle [angle #f]
+                #:altitude [altitude #f]
                 #:az [az #f] #:alt [alt #f]  ; backward-compatible aliases
                 #:title [title (plot-title)]
                 #:x-label [x-label (plot-x-label)]
@@ -229,6 +236,13 @@
     [(and y-max (not (rational? y-max)))  (fail/kw "#f or rational" '#:y-max y-max)]
     [(and z-min (not (rational? z-min)))  (fail/kw "#f or rational" '#:z-min z-min)]
     [(and z-max (not (rational? z-max)))  (fail/kw "#f or rational" '#:z-max z-max)])
+  (cond ;; because this function is exported via `unsafe-provide`
+    [(and out-kind (not (plot-file-format/c out-kind)))
+     (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
+    [(and fgcolor (not (plot-color/c fgcolor)))
+     (fail/kw "plot-color/c" '#:fgcolor fgcolor)]
+    [(and bgcolor (not (plot-color/c bgcolor)))
+     (fail/kw "plot-color/c" '#:bgcolor bgcolor)])
   
   (parameterize ([plot-foreground  (if fgcolor fgcolor (plot-foreground))]
                  [plot-background  (if bgcolor bgcolor (plot-background))])

--- a/plot-lib/plot/private/common/contract.rkt
+++ b/plot-lib/plot/private/common/contract.rkt
@@ -50,6 +50,9 @@
                                            'bdiagonal-hatch  'fdiagonal-hatch 'crossdiag-hatch
                                            'horizontal-hatch 'vertical-hatch  'cross-hatch)))
 
+(define plot-file-format/c
+  (or/c 'auto 'png 'jpeg 'xmb 'xpm 'bmp 'ps 'pdf 'svg))
+
 (module typed-defs typed/racket/base
   (require "type-doc.rkt")
   

--- a/plot-test/plot/tests/PRs/plot-unsafe-provide.rkt
+++ b/plot-test/plot/tests/PRs/plot-unsafe-provide.rkt
@@ -1,0 +1,480 @@
+#lang racket/base
+
+;; Check that bad arguments to plot functions do not cause segfaults.
+;;  (since these functions are exported via `unsafe-provide`)
+;;
+;; To run these tests:
+;; 1. `raco test <THIS-FILE>`
+;; 2. uncomment the code at the bottom of this file,
+;;    run `racket <THIS-FILE>`
+;;    check that the tests output contract violations --- nothing worse
+;;
+;; It would be good to eliminate step 2, but rackunit and `with-handlers` don't
+;; catch the exceptions.
+
+(require plot rackunit)
+
+(define BAD-ARG ;; none of the plot functions expect a box
+  (box #f))
+
+(define example-renderer2
+  (points (for/list ((i (in-range 0 4))) (list 0 i)) #:label "some points"))
+
+(define example-nonrenderer2
+  (invisible-rect -5 5 -5 5))
+
+(define example-renderer3
+  (vector-field3d (λ (x y z) (vector x z y)) -2 2 -2 2 -2 2))
+
+(define example-nonrenderer3
+  (invisible-rect3d -5 5 -5 5 -5 5))
+
+;; -----------------------------------------------------------------------------
+;; These tests should all pass
+
+(module+ test
+  (test-case "plot-snip"
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 BAD-ARG))))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:x-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:x-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:y-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:y-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:width BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:height BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:title BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:x-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:y-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-snip (list example-renderer2 example-nonrenderer2)
+                   #:legend-anchor BAD-ARG))))
+
+  (test-case "plot-frame"
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-frame (list example-renderer2 example-nonrenderer2)
+                    #:x-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-frame (list example-renderer2 example-nonrenderer2)
+                    #:x-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-frame (list example-renderer2 example-nonrenderer2)
+                    #:y-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-frame (list example-renderer2 example-nonrenderer2)
+                    #:y-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-frame (list example-renderer2 example-nonrenderer2)
+                    #:width BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-frame (list example-renderer2 example-nonrenderer2)
+                    #:height BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot-frame (list example-renderer2 example-nonrenderer2)
+                    #:legend-anchor BAD-ARG))))
+
+  (test-case "plot"
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:x-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:x-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:y-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:y-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:width BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:height BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:title BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:x-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:y-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:legend-anchor BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:out-file BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:out-kind BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:fgcolor BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:bgcolor BAD-ARG)))
+
+    (check-not-exn ;; unused argument
+      (lambda ()
+        (plot (list example-renderer2 example-nonrenderer2)
+              #:lncolor BAD-ARG))))
+
+  (test-case "plot3d-snip"
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 BAD-ARG))))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:x-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:x-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:y-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:y-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:z-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:z-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:width BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:height BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:angle BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:altitude BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:title BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:x-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:y-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:z-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-snip (list example-renderer3 example-nonrenderer3)
+                     #:legend-anchor BAD-ARG))))
+
+  (test-case "plot3d-frame"
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                     #:x-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                     #:x-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                     #:y-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                     #:y-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                     #:z-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                     #:z-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                     #:width BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                     #:height BAD-ARG))))
+
+  (test-case "plot3d"
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:x-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:x-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:y-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:y-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:z-min BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:z-max BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:width BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:height BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:angle BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:altitude BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:az BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:alt BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:title BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:x-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:y-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:z-label BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:legend-anchor BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:out-file BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:out-kind BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:fgcolor BAD-ARG)))
+
+    (check-exn exn:fail:contract?
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:bgcolor BAD-ARG)))
+
+    (check-not-exn ;; unused argument
+      (lambda ()
+        (plot3d (list example-renderer3 example-nonrenderer3)
+                     #:lncolor BAD-ARG))))
+
+)
+
+;; -----------------------------------------------------------------------------
+;; When uncommented, these expressions should raise contract error messages
+;; that blame `BAD-ARG` (given: '#&#f)
+
+#;(let ()
+    (plot-frame BAD-ARG)
+    (plot-frame (list example-renderer2 example-nonrenderer2)
+                #:title BAD-ARG)
+    (plot-frame (list example-renderer2 example-nonrenderer2)
+                #:x-label BAD-ARG)
+    (plot-frame (list example-renderer2 example-nonrenderer2)
+                #:y-label BAD-ARG)
+    (plot3d-frame BAD-ARG)
+    (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                 #:angle BAD-ARG)
+    (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                 #:altitude BAD-ARG)
+    (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                 #:title BAD-ARG)
+    (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                 #:x-label BAD-ARG)
+    (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                 #:y-label BAD-ARG)
+    (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                 #:z-label BAD-ARG)
+    (plot3d-frame (list example-renderer3 example-nonrenderer3)
+                 #:legend-anchor BAD-ARG)
+    (void))


### PR DESCRIPTION
This PR adds regression tests for f53d103d37827ea83b41015da59fcd519a9345e0 , to check that the plot3d functions don't segfault on bad arguments.

While testing I realized I made a mistake yesterday (#27) --- plot's parameters are **not** always guarded with a contract. The parameters **do** seem safe against segfaults. But a bad value can give a bad error message, so this PR explicitly checks all keyword arguments to plot3d functions.

Also adds a `plot-file-format/c` contract. (Not necessary, but I think it's a good idea.)

(cc @stamourv I am not suggesting we merge this pull request into the release)