### PR TITLE
Add 'auto Anchor and 'none Point-Sym for `point-label` and related functions

### DIFF
--- a/plot-doc/plot/scribblings/contracts.scrbl
+++ b/plot-doc/plot/scribblings/contracts.scrbl
@@ -102,7 +102,7 @@ The contract for the @(racket #:sym) arguments in @(racket points) and @(racket 
         'circle7           'circle8          'bullet
         'fullcircle1       'fullcircle2      'fullcircle3
         'fullcircle4       'fullcircle5      'fullcircle6
-        'fullcircle7       'fullcircle8)]{
+        'fullcircle7       'fullcircle8      'none)]{
 A list containing the symbols that are valid @(racket points) symbols.
 }
 

--- a/plot-doc/plot/scribblings/contracts.scrbl
+++ b/plot-doc/plot/scribblings/contracts.scrbl
@@ -32,9 +32,24 @@ Identifies values that meet the contract @racket[elem-contract], lists of such v
 
 @defthing[anchor/c contract? #:value (one-of/c 'top-left    'top    'top-right
                                                'left        'center 'right
-                                               'bottom-left 'bottom 'bottom-right)]{
+                                               'bottom-left 'bottom 'bottom-right
+                                               'auto)]{
 The contract for @(racket anchor) arguments and parameters, such as @(racket plot-legend-anchor).
-}
+
+The @racket['auto] anchor will place labels so they are visible on the plot
+area.  This anchor type is useful for @(racket point-label) and @(racket
+function-label) renderers where the labeled point might be at the edge of the
+plot area and the user does not wish to calculate the exact anchor for the
+label.
+
+The @racket['auto] anchor will choose one of the @racket['bottom-left],
+@racket['bottom-right], @racket['top-left] or @racket['top-right] placements,
+in that order, and will use the first one that would result in the label being
+completely visible.
+
+The @racket['auto] anchor is only valid for placement of text labels, for all
+other use cases, the @racket['auto] anchor is always the same as
+@racket['bottom-left].}
 
 @defthing[color/c contract? #:value (or/c (list/c real? real? real?)
                                           string? symbol?

--- a/plot-lib/plot/private/common/draw-attribs.rkt
+++ b/plot-lib/plot/private/common/draw-attribs.rkt
@@ -21,7 +21,8 @@
   (case a
     [(top-left)  'bottom-right] [(top)  'bottom] [(top-right)  'bottom-left] [(right)  'left]
     [(bottom-right)  'top-left] [(bottom)  'top] [(bottom-left)  'top-right] [(left)  'right]
-    [(center)  'center]))
+    [(center)  'center]
+    [(auto) 'auto]))
 
 ;; ===================================================================================================
 ;; Draw paramter normalization

--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -527,6 +527,7 @@
                      [else  (set-brush brush-color 'transparent)
                             real-sym]))
              (case line-sym
+               [(none)    void]
                ; circles
                [(circle)  (make-draw-circle-glyph r)]
                ; squares

--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -609,7 +609,7 @@
         (cond
           [(and x-min x-max)
            (case (plot-legend-anchor)
-             [(top-left left bottom-left)     x-min]
+             [(top-left left bottom-left auto)     x-min]
              [(top-right right bottom-right)  (- x-max legend-x-size)]
              [(center bottom top)             (- (* 1/2 (+ x-min x-max))
                                                  (* 1/2 legend-x-size))])]
@@ -620,7 +620,7 @@
         (cond
           [(and y-min y-max)
            (case (plot-legend-anchor)
-             [(top-left top top-right)           y-min]
+             [(top-left top top-right auto)      y-min]
              [(bottom-left bottom bottom-right)  (- y-max legend-y-size)]
              [(center left right)                (- (* 1/2 (+ y-min y-max))
                                                     (* 1/2 legend-y-size))])]

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -60,7 +60,7 @@
         'circle7           'circle8          'bullet
         'fullcircle1       'fullcircle2      'fullcircle3
         'fullcircle4       'fullcircle5      'fullcircle6
-        'fullcircle7       'fullcircle8)))
+        'fullcircle7       'fullcircle8      'none)))
 
 (deftype (List-Generator A B) (U (Listof B) (-> A (Listof B))))
 

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -13,7 +13,8 @@
 (deftype Anchor
   (U 'top-left    'top    'top-right
      'left        'center 'right
-     'bottom-left 'bottom 'bottom-right))
+     'bottom-left 'bottom 'bottom-right
+     'auto))
 
 (deftype Color
   (U (List Real Real Real)


### PR DESCRIPTION
An `'auto` `Anchor` type can be used to position the label inside the plot, without needing to know the plot edges.  A `'none` `Point-Sym` will cause `point-label` to not show the current location on the plot, it will just show the label.

Example code:

```racket
#lang racket
(require plot)
    
(plot
 ;; Add labels on the edges of the plot area.  Each label will be positioned
 ;; so it is inside the plot area
 (list (point-label (vector 0 10) #:anchor 'auto)
       (point-label (vector 0 -10) #:anchor 'auto)
       ;; Side labels have no corresponding point
       (point-label (vector 10 0) #:anchor 'auto #:point-sym 'none)
       (point-label (vector -10 0) #:anchor 'auto #:point-sym 'none))
 #:x-min -10 #:x-max 10
 #:y-min -10 #:y-max 10)
```

Results in:
<img width="314" alt="auto-anchor" src="https://user-images.githubusercontent.com/11592690/35963697-84359a2e-0cf0-11e8-8ad0-e3a4ceb64ba3.PNG">


This pull request is a step towards interactive overlays based on renderer trees as suggested by @bennn in #32 .  The feature will be most useful to add point labels interactively, but it can be useful independently of that.