### PR TITLE
 Add `point-pict` 2d renderer, similar to `point-label`

### DIFF
--- a/plot-doc/plot/scribblings/contracts.scrbl
+++ b/plot-doc/plot/scribblings/contracts.scrbl
@@ -102,7 +102,7 @@ The contract for the @(racket #:sym) arguments in @(racket points) and @(racket 
         'circle7           'circle8          'bullet
         'fullcircle1       'fullcircle2      'fullcircle3
         'fullcircle4       'fullcircle5      'fullcircle6
-        'fullcircle7       'fullcircle8)]{
+        'fullcircle7       'fullcircle8      'none)]{
 A list containing the symbols that are valid @(racket points) symbols.
 }
 

--- a/plot-doc/plot/scribblings/contracts.scrbl
+++ b/plot-doc/plot/scribblings/contracts.scrbl
@@ -32,9 +32,24 @@ Identifies values that meet the contract @racket[elem-contract], lists of such v
 
 @defthing[anchor/c contract? #:value (one-of/c 'top-left    'top    'top-right
                                                'left        'center 'right
-                                               'bottom-left 'bottom 'bottom-right)]{
+                                               'bottom-left 'bottom 'bottom-right
+                                               'auto)]{
 The contract for @(racket anchor) arguments and parameters, such as @(racket plot-legend-anchor).
-}
+
+The @racket['auto] anchor will place labels so they are visible on the plot
+area.  This anchor type is useful for @(racket point-label) and @(racket
+function-label) renderers where the labeled point might be at the edge of the
+plot area and the user does not wish to calculate the exact anchor for the
+label.
+
+The @racket['auto] anchor will choose one of the @racket['bottom-left],
+@racket['bottom-right], @racket['top-left] or @racket['top-right] placements,
+in that order, and will use the first one that would result in the label being
+completely visible.
+
+The @racket['auto] anchor is only valid for placement of text labels, for all
+other use cases, the @racket['auto] anchor is always the same as
+@racket['bottom-left].}
 
 @defthing[color/c contract? #:value (or/c (list/c real? real? real?)
                                           string? symbol?

--- a/plot-doc/plot/scribblings/contracts.scrbl
+++ b/plot-doc/plot/scribblings/contracts.scrbl
@@ -37,10 +37,9 @@ Identifies values that meet the contract @racket[elem-contract], lists of such v
 The contract for @(racket anchor) arguments and parameters, such as @(racket plot-legend-anchor).
 
 The @racket['auto] anchor will place labels so they are visible on the plot
-area.  This anchor type is useful for @(racket point-label) and @(racket
-function-label) renderers where the labeled point might be at the edge of the
-plot area and the user does not wish to calculate the exact anchor for the
-label.
+area.  This anchor type is useful for @(racket point-label) and similar
+renderers where the labeled point might be at the edge of the plot area and
+the user does not wish to calculate the exact anchor for the label.
 
 The @racket['auto] anchor will choose one of the @racket['bottom-left],
 @racket['bottom-right], @racket['top-left] or @racket['top-right] placements,

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -738,6 +738,27 @@ If @(racket label) is @(racket #f), the point is labeled with its position.
 The remaining labeled-point functions are defined in terms of this one.
 }
 
+@defproc[(point-pict
+          [v (sequence/c real?)]
+          [pict pict?]
+          [#:anchor anchor anchor/c (label-anchor)]
+          [#:point-color point-color plot-color/c (point-color)]
+          [#:point-fill-color point-fill-color (or/c plot-color/c 'auto) 'auto]
+          [#:point-size point-size (>=/c 0) (label-point-size)]
+          [#:point-line-width point-line-width (>=/c 0) (point-line-width)]
+          [#:point-sym point-sym point-sym/c 'fullcircle]
+          [#:alpha alpha (real-in 0 1) (label-alpha)]
+          ) renderer2d?]{
+Returns a renderer that draws a point with a pict as the label.
+
+@interaction[#:eval plot-eval
+                    (require pict)
+                    (plot (list (function sqr 0 2)
+                                (point-pict (vector 1 1) (standard-fish 40 15))))]
+
+The remaining labeled-pict functions are defined in terms of this one.
+}
+
 @defproc[(function-label
           [f  (real? . -> . real?)] [x real?] [label (or/c string? #f) #f]
           [#:color color plot-color/c (plot-foreground)]
@@ -761,6 +782,19 @@ Returns a renderer that draws a labeled point on a function's graph.
                                                 #:anchor 'right)))]
 }
 
+@defproc[(function-pict
+          [f  (real? . -> . real?)] [x real?] [pict pict?]
+          [#:anchor anchor anchor/c (label-anchor)]
+          [#:point-color point-color plot-color/c (point-color)]
+          [#:point-fill-color point-fill-color (or/c plot-color/c 'auto) 'auto]
+          [#:point-size point-size (>=/c 0) (label-point-size)]
+          [#:point-line-width point-line-width (>=/c 0) (point-line-width)]
+          [#:point-sym point-sym point-sym/c 'fullcircle]
+          [#:alpha alpha (real-in 0 1) (label-alpha)]
+          ) renderer2d?]{
+Returns a renderer that draws a point with a pict as the label on a function's graph.
+}
+
 @defproc[(inverse-label
           [f  (real? . -> . real?)] [y real?] [label (or/c string? #f) #f]
           [#:color color plot-color/c (plot-foreground)]
@@ -778,6 +812,20 @@ Returns a renderer that draws a labeled point on a function's graph.
           ) renderer2d?]{
 Returns a renderer that draws a labeled point on a function's inverted graph.
 }
+
+@defproc[(inverse-pict
+          [f  (real? . -> . real?)] [y real?] [pict pict?]
+          [#:anchor anchor anchor/c (label-anchor)]
+          [#:point-color point-color plot-color/c (point-color)]
+          [#:point-fill-color point-fill-color (or/c plot-color/c 'auto) 'auto]
+          [#:point-size point-size (>=/c 0) (label-point-size)]
+          [#:point-line-width point-line-width (>=/c 0) (point-line-width)]
+          [#:point-sym point-sym point-sym/c 'fullcircle]
+          [#:alpha alpha (real-in 0 1) (label-alpha)]
+          ) renderer2d?]{
+Returns a renderer that draws a point with a pict as the label on a function's inverted graph.
+}
+
 
 @defproc[(parametric-label
           [f (real? . -> . (sequence/c real?))] [t real?] [label (or/c string? #f) #f]
@@ -797,6 +845,19 @@ Returns a renderer that draws a labeled point on a function's inverted graph.
 Returns a renderer that draws a labeled point on a parametric function's graph.
 }
 
+@defproc[(parametric-pict
+          [f (real? . -> . (sequence/c real?))] [t real?] [pict pict?]
+          [#:anchor anchor anchor/c (label-anchor)]
+          [#:point-color point-color plot-color/c (point-color)]
+          [#:point-fill-color point-fill-color (or/c plot-color/c 'auto) 'auto]
+          [#:point-size point-size (>=/c 0) (label-point-size)]
+          [#:point-line-width point-line-width (>=/c 0) (point-line-width)]
+          [#:point-sym point-sym point-sym/c 'fullcircle]
+          [#:alpha alpha (real-in 0 1) (label-alpha)]
+          ) renderer2d?]{
+Returns a renderer that draws a point with a pict as the label on a parametric function's graph.
+}
+
 
 @defproc[(polar-label
           [f (real? . -> . real?)] [θ real?] [label (or/c string? #f) #f]
@@ -814,4 +875,18 @@ Returns a renderer that draws a labeled point on a parametric function's graph.
           [#:alpha alpha (real-in 0 1) (label-alpha)]
           ) renderer2d?]{
 Returns a renderer that draws a labeled point on a polar function's graph.
+}
+
+
+@defproc[(polar-pict
+          [f (real? . -> . real?)] [θ real?] [pict pict?]
+          [#:anchor anchor anchor/c (label-anchor)]
+          [#:point-color point-color plot-color/c (point-color)]
+          [#:point-fill-color point-fill-color (or/c plot-color/c 'auto) 'auto]
+          [#:point-size point-size (>=/c 0) (label-point-size)]
+          [#:point-line-width point-line-width (>=/c 0) (point-line-width)]
+          [#:point-sym point-sym point-sym/c 'fullcircle]
+          [#:alpha alpha (real-in 0 1) (label-alpha)]
+          ) renderer2d?]{
+Returns a renderer that draws a point with a pict as the label on a polar function's graph.
 }

--- a/plot-lib/plot/no-gui.rkt
+++ b/plot-lib/plot/no-gui.rkt
@@ -93,10 +93,15 @@
  y-tick-lines
  tick-grid
  point-label
+ point-pict
  parametric-label
+ parametric-pict
  polar-label
+ polar-pict
  function-label
- inverse-label)
+ function-pict
+ inverse-label
+ inverse-pict)
 
 ;; ===================================================================================================
 ;; 3D exports

--- a/plot-lib/plot/private/common/draw-attribs.rkt
+++ b/plot-lib/plot/private/common/draw-attribs.rkt
@@ -21,7 +21,8 @@
   (case a
     [(top-left)  'bottom-right] [(top)  'bottom] [(top-right)  'bottom-left] [(right)  'left]
     [(bottom-right)  'top-left] [(bottom)  'top] [(bottom-left)  'top-right] [(left)  'right]
-    [(center)  'center]))
+    [(center)  'center]
+    [(auto) 'auto]))
 
 ;; ===================================================================================================
 ;; Draw paramter normalization

--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -527,6 +527,7 @@
                      [else  (set-brush brush-color 'transparent)
                             real-sym]))
              (case line-sym
+               [(none)    void]
                ; circles
                [(circle)  (make-draw-circle-glyph r)]
                ; squares

--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -609,7 +609,7 @@
         (cond
           [(and x-min x-max)
            (case (plot-legend-anchor)
-             [(top-left left bottom-left)     x-min]
+             [(top-left left bottom-left auto)     x-min]
              [(top-right right bottom-right)  (- x-max legend-x-size)]
              [(center bottom top)             (- (* 1/2 (+ x-min x-max))
                                                  (* 1/2 legend-x-size))])]
@@ -620,7 +620,7 @@
         (cond
           [(and y-min y-max)
            (case (plot-legend-anchor)
-             [(top-left top top-right)           y-min]
+             [(top-left top top-right auto)      y-min]
              [(bottom-left bottom bottom-right)  (- y-max legend-y-size)]
              [(center left right)                (- (* 1/2 (+ y-min y-max))
                                                     (* 1/2 legend-y-size))])]

--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -576,6 +576,11 @@
         (for ([v  (in-list vs)])
           (draw-glyph v))))
 
+    (define/public (draw-pict pict v [anchor 'top-left] [dist 0])
+      (when (vrational? v)
+        (match-define (vector x y) v)
+        (draw-pict/anchor dc pict x y anchor dist)))
+
     ;; ===============================================================================================
     ;; Legend
 

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -3,8 +3,10 @@
 (require (for-syntax racket/base)
          typed/racket/draw
          typed/racket/class
+         typed/pict
          "type-doc.rkt"
          "math.rkt")
+
 
 (provide (all-defined-out))
 
@@ -127,4 +129,5 @@
    [draw-tick (-> (Vectorof Real) Real Real Void)]
    [draw-arrow-glyph (-> (Vectorof Real) Real Real Void)]
    [draw-glyphs (-> (Listof (Vectorof Real)) Point-Sym Nonnegative-Real Void)]
+   [draw-pict (->* [pict (Vectorof Real)] (Anchor Real) Void)]
    [draw-legend (-> (Listof legend-entry) Rect Void)]))

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -60,7 +60,7 @@
         'circle7           'circle8          'bullet
         'fullcircle1       'fullcircle2      'fullcircle3
         'fullcircle4       'fullcircle5      'fullcircle6
-        'fullcircle7       'fullcircle8)))
+        'fullcircle7       'fullcircle8      'none)))
 
 (deftype (List-Generator A B) (U (Listof B) (-> A (Listof B))))
 

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -13,7 +13,8 @@
 (deftype Anchor
   (U 'top-left    'top    'top-right
      'left        'center 'right
-     'bottom-left 'bottom 'bottom-right))
+     'bottom-left 'bottom 'bottom-right
+     'auto))
 
 (deftype Color
   (U (List Real Real Real)

--- a/plot-lib/plot/private/plot2d/plot-area.rkt
+++ b/plot-lib/plot/private/plot2d/plot-area.rkt
@@ -1,6 +1,6 @@
 #lang typed/racket/base
 
-(require typed/racket/class typed/racket/draw racket/match racket/math racket/list racket/flonum
+(require typed/racket/class typed/racket/draw racket/match racket/math racket/list racket/flonum typed/pict
          (only-in math/flonum fl)
          "../common/type-doc.rkt"
          "../common/types.rkt"
@@ -65,6 +65,7 @@
          [put-glyphs (-> (Listof (Vectorof Real)) Point-Sym Nonnegative-Real Void)]
          [put-arrow (-> (Vectorof Real) (Vectorof Real) Void)]
          [put-tick (-> (Vectorof Real) Real Real Void)]
+         [put-pict (->* [pict (Vectorof Real)] [Anchor Real] Void)]
          ))
 
 (: 2d-plot-area% 2D-Plot-Area%)
@@ -761,4 +762,9 @@
       (let ([v  (exact-vector2d v)])
         (when (and v (in-bounds? v))
           (send pd draw-tick (plot->dc v) r angle))))
+
+    (define/public (put-pict pict v [anchor 'top-left] [dist 0])
+      (let ([v  (exact-vector2d v)])
+        (when (and v (in-bounds? v))
+          (send pd draw-pict pict (plot->dc v) anchor dist))))
     ))


### PR DESCRIPTION
The `point-pict` function adds a point to the graph and specifies a pict object to be displayed as the label.  This is similar to the `point-label` function, which can only show a string as the label.

`function-pict`, `inverse-pict`, `parametric-pict` and `polar-pict` are added similar to their *-label counterparts.

Sample code:

```racket
#lang racket
(require plot pict)

(define blue-fish (standard-fish 40 15 #:color "lightblue"))
(define red-fish (standard-fish 40 15 #:color "salmon"))

(define (f t) (vector (cos t) (sin t)))

(plot
 (list (point-pict (vector 0 10) blue-fish #:anchor 'auto)
       (point-pict (vector 0 -10) blue-fish #:anchor 'auto #:point-size 15)
       (point-pict (vector 10 0) blue-fish #:anchor 'auto #:point-sym 'none)
       (point-pict (vector -10 0) blue-fish #:anchor 'auto #:point-sym 'none)
       (parametric f 0 (* 2 pi))
       (parametric-pict f (/ pi 2) red-fish #:anchor 'bottom )
       (function sin)
       (function-pict sin -5 red-fish #:anchor 'left)
       (polar-pict (lambda (a) (* 8 (sin a))) (/ pi 4) red-fish)
       (inverse-pict asin 1 red-fish))
 #:x-min -10 #:x-max 10
 #:y-min -10 #:y-max 10)
```

Produces:

<img width="327" alt="point-snip-sample" src="https://user-images.githubusercontent.com/11592690/36059897-c00bab0e-0e78-11e8-94a9-d90062d6dd50.PNG">

This pull request is built on top of #33, and it contains its commits, only the last commit implements this functionality.