### PR TITLE
Extend `rectangles` renderer to accept open intervals

### DIFF
--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -550,9 +550,9 @@ For example, the canonical saddle, with its gradient field superimposed:
 Returns a renderer that draws rectangles.
 
 The rectangles are given as a sequence of sequences of intervals---each inner
-sequence defines the bounds of a rectangle.  Any of the bounds can be #f, in
-which case the rectangle extents to the edge of the plot area in the
-respective direction.
+sequence defines the bounds of a rectangle.  Any of the bounds can be
+@racket[-inf.0] or @racket[+inf.0], in which case the rectangle extents to the
+edge of the plot area in the respective direction.
 
 For example,
 @interaction[#:eval plot-eval (plot (rectangles (list (vector (ivl -1 0) (ivl -1 1))

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -548,7 +548,13 @@ For example, the canonical saddle, with its gradient field superimposed:
           [#:label label (or/c string? #f) #f]
           ) renderer2d?]{
 Returns a renderer that draws rectangles.
-The rectangles are given as a sequence of sequences of intervals---each inner sequence defines the bounds of a rectangle. For example,
+
+The rectangles are given as a sequence of sequences of intervals---each inner
+sequence defines the bounds of a rectangle.  Any of the bounds can be #f, in
+which case the rectangle extents to the edge of the plot area in the
+respective direction.
+
+For example,
 @interaction[#:eval plot-eval (plot (rectangles (list (vector (ivl -1 0) (ivl -1 1))
                                                       (vector (ivl 0 2) (ivl 1 2)))))]
 }

--- a/plot-doc/plot/scribblings/utils.scrbl
+++ b/plot-doc/plot/scribblings/utils.scrbl
@@ -370,7 +370,7 @@ Returns @racket[#t] if every element of @racket[v] is @racket[rational?].
 @;----------------------------------------------------------------------------------------------------
 @subsection[#:tag "math.intervals"]{Intervals and Interval Functions}
 
-@defstruct[ivl ([min (or/c real? #f)] [max (or/c real? #f)])]{
+@defstruct[ivl ([min real?] [max real?])]{
 Represents a closed interval.
 
 An interval with two real-valued endpoints always contains the endpoints in order:

--- a/plot-doc/plot/scribblings/utils.scrbl
+++ b/plot-doc/plot/scribblings/utils.scrbl
@@ -370,7 +370,7 @@ Returns @racket[#t] if every element of @racket[v] is @racket[rational?].
 @;----------------------------------------------------------------------------------------------------
 @subsection[#:tag "math.intervals"]{Intervals and Interval Functions}
 
-@defstruct[ivl ([min real?] [max real?])]{
+@defstruct[ivl ([min (or/c real? #f)] [max (or/c real? #f)])]{
 Represents a closed interval.
 
 An interval with two real-valued endpoints always contains the endpoints in order:

--- a/plot-lib/plot/private/plot2d/rectangle.rkt
+++ b/plot-lib/plot/private/plot2d/rectangle.rkt
@@ -18,14 +18,17 @@
                               2D-Render-Proc))
 (define ((rectangles-render-proc rects color style line-color line-width line-style alpha label)
          area)
-  (match-define (vector (ivl x-min x-max) (ivl y-min y-max)) (send area get-bounds-rect))
+  (match-define (vector (ivl bx-min bx-max) (ivl by-min by-max)) (send area get-bounds-rect))
   (send area put-pen line-color line-width line-style)
   (send area put-brush color style)
   (send area put-alpha alpha)
   (for ([rect  (in-list rects)])
     (match-define (vector (ivl vx-min vx-max) (ivl vy-min vy-max)) rect)
-    (send area put-rect (vector (ivl (or vx-min x-min) (or vx-max x-max))
-                                (ivl (or vy-min y-min) (or vy-max y-max)))))
+    (define x-min (if (or (eqv? vx-min -inf.0) (eqv? vx-min -inf.f)) bx-min vx-min))
+    (define x-max (if (or (eqv? vx-max +inf.0) (eqv? vx-max +inf.f)) bx-max vx-max))
+    (define y-min (if (or (eqv? vy-min -inf.0) (eqv? vy-min -inf.f)) by-min vy-min))
+    (define y-max (if (or (eqv? vy-max +inf.0) (eqv? vy-max +inf.f)) by-max vy-max))
+    (send area put-rect (vector (ivl x-min x-max) (ivl y-min y-max))))
   
   (cond [label  (rectangle-legend-entry label color style line-color line-width line-style)]
         [else  empty]))
@@ -62,9 +65,36 @@
     [(or (> alpha 1) (not (rational? alpha)))  (fail/kw "real in [0,1]" '#:alpha alpha)]
     [else
      (let ([rects  (sequence->listof-vector 'rectangles rects 2)])
-       (renderer2d #f #f default-ticks-fun
-                   (rectangles-render-proc rects color style line-color line-width line-style
-                                           alpha label)))]))
+       (match-define (list (vector (ivl #{x1s : (Listof (U Real #f))}
+                                        #{x2s : (Listof (U Real #f))})
+                                   (ivl #{y1s : (Listof (U Real #f))}
+                                        #{y2s : (Listof (U Real #f))}))
+                           ...)
+         rects)
+       (define (valid? num)
+         (and (real? num) (not (eqv? num +nan.0)) (not (eqv? num +nan.f))))
+       (define rxs (filter valid? (append x1s x2s)))
+       (define rys (filter valid? (append y1s y2s)))
+       (cond
+         [(or (empty? rxs) (empty? rys))  (renderer2d #f #f #f #f)]
+         [else
+          (let ([x-min  (if x-min x-min (apply min* rxs))]
+                [x-max  (if x-max x-max (apply max* rxs))]
+                [y-min  (if y-min y-min (apply min* rys))]
+                [y-max  (if y-max y-max (apply max* rys))])
+            ;; Only provide bounds if all rectangle dimensions are finite.
+            ;; Infinite limits mean "extend to the edge of the plot".
+            ;;
+            ;; We cannot simply discard infinite limits, as these bounds will
+            ;; be used for clipping the rectangles and this might result in
+            ;; rectangles that don't extend all the way to the edge.
+            (define bounds
+              (and (rational? x-min) (rational? x-max)
+                   (rational? y-min) (rational? y-max)
+                   (vector (ivl x-min x-max) (ivl y-min y-max))))
+            (renderer2d bounds #f default-ticks-fun
+                        (rectangles-render-proc rects color style line-color line-width line-style
+                                                alpha label)))]))]))
 
 ;; ===================================================================================================
 ;; Real histograms (or histograms on the real line)


### PR DESCRIPTION
When #f is specified to one of the interval bounds of the `rectangles`
renderer, the rectangle will extend to the edge of the plot area in the
direction of that bound.  Example:

```racket
#lang racket
(require plot)
(plot (rectangles (list (vector (ivl 2 3) (ivl #f #f))
                        (vector (ivl #f #f) (ivl 2 3))
                        ;; Vertical extent from 0 to the top
                        (vector (ivl 5 6) (ivl 0 #f)))
                  #:line-style 'transparent
                  #:alpha 0.5)
      #:x-min -10 #:x-max 10
      #:y-min -10 #:y-max 10)
```

Implementation note: the rectangles renderer code used to compute the bounds
of the plot based on the bounds of the rectangles, this code is unnecessary
and complicates the case where the intervals are open-ended.  It was removed.