### PR TITLE
Update 2d-plot-snip% to allow interactive overlays.

### DIFF
--- a/plot-doc/plot/scribblings/common.rkt
+++ b/plot-doc/plot/scribblings/common.rkt
@@ -7,6 +7,7 @@
                     db
                     plot
                     plot/utils
+                    plot/snip
                     (only-in racket/sequence sequence/c)))
 
 (provide (all-defined-out)
@@ -16,6 +17,7 @@
                                   pict
                                   db
                                   plot
+                                  plot/snip
                                   plot/utils)
                     sequence/c))
 

--- a/plot-doc/plot/scribblings/plotting.scrbl
+++ b/plot-doc/plot/scribblings/plotting.scrbl
@@ -94,7 +94,7 @@ The @(racket #:az) and @(racket #:alt) keyword arguments are backward-compatible
 }
 
 @defproc[(plot-snip [<plot-argument> <plot-argument-contract>] ...)
-         (is-a?/c snip%)]
+         (is-a?/c 2d-plot-snip+c%)]
 @defproc[(plot3d-snip [<plot-argument> <plot-argument-contract>] ...)
          (is-a?/c snip%)]
 @defproc[(plot-frame [<plot-argument> <plot-argument-contract>] ...)

--- a/plot-doc/plot/scribblings/plotting.scrbl
+++ b/plot-doc/plot/scribblings/plotting.scrbl
@@ -94,7 +94,7 @@ The @(racket #:az) and @(racket #:alt) keyword arguments are backward-compatible
 }
 
 @defproc[(plot-snip [<plot-argument> <plot-argument-contract>] ...)
-         (is-a?/c 2d-plot-snip+c%)]
+         (is-a?/c 2d-plot-snip%)]
 @defproc[(plot3d-snip [<plot-argument> <plot-argument-contract>] ...)
          (is-a?/c snip%)]
 @defproc[(plot-frame [<plot-argument> <plot-argument-contract>] ...)

--- a/plot-doc/plot/scribblings/plotting.scrbl
+++ b/plot-doc/plot/scribblings/plotting.scrbl
@@ -107,6 +107,10 @@ These procedures accept the same arguments as @(racket plot) and @(racket plot3d
 Use @(racket plot-frame) and @(racket plot3d-frame) to create a @(racket frame%) regardless of the value of @(racket plot-new-window?). The frame is initially hidden.
 
 Use @(racket plot-snip) and @(racket plot3d-snip) to create an interactive @(racket snip%) regardless of the value of @(racket plot-new-window?).
+
+@racket[snip%] objects returned by @(racket plot-snip) can be used to
+construct interactive plots.  See @secref["2d-plot-snip-interactive-overlays"]
+for more details.
 }
 
 @section{Non-GUI Plotting Procedures}

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -890,3 +890,99 @@ Returns a renderer that draws a labeled point on a polar function's graph.
           ) renderer2d?]{
 Returns a renderer that draws a point with a pict as the label on a polar function's graph.
 }
+
+@section[#:tag "2d-plot-snip-interactive-overlays"]{Interactive Overlays for 2D plots}
+
+An plot object returned by @racket[plot-snip] can be set up to provide
+interactive overlays, such as displaying the current value of the plot
+function at he mouse cursor.  Two methods are available on the returned
+@racket[snip%] object for this purpose.
+
+@defclass[2d-plot-snip% snip% ()]{
+
+An instance of this class is returned by @racket[plot-snip].
+
+@defmethod[(set-mouse-event-callback [callback (or/c plot-mouse-event-callback/c #f)]) any/c]{
+
+Set a callback function to be invoked with mouse events from the snip.  The
+callback is invoked with the actual snip object, the @racket[mouse-event%] and
+the X, Y position of the mouse in plot coordinates -- these are in the same
+coordinate system used by the renderers in the plot.  The X, Y values are
+@racket[#f] when the mouse is outside the plot area (for example, when the
+mouse is over the axis area).
+
+When a callback is installed, the default zoom functionality of the plot snips
+is disabled.  This can be restored by calling
+@racket[set-mouse-event-callback] with a @racket[#f] argument.
+
+}
+
+@defmethod[(set-overlay-renderers [renderers (or/c #f (treeof renderer2d?))]) any/c]{
+
+Set a list of renderers (or more generally, a tree of renderers) to be drawn
+on top of the existing plot.  This can be any combination of 2D renderers, but
+it will not be able to modify the axes or the dimensions of the plot area.
+Only one set of overlay renderers can be installed, calling this method a
+second time will replace the previous overlays.  Specifying @racket[#f] as the
+renderers will cause overlays to be disabled.
+
+}
+}
+
+@defthing[plot-mouse-event-callback/c contract? #:value (-> (is-a?/c snip%)
+                                                       (is-a?/c mouse-event%)
+                                                       (or/c real? #f)
+                                                       (or/c real? #f) any/c)]{
+A contract for callback functions passed to @racket[set-mouse-event-callback].
+}
+
+
+For example, if you evaluate the code below in DrRacket, the resulting plot
+will show a vertical line tracking the mouse and the current plot position is
+shown on a label.  This is achieved by adding a mouse callback to the plot
+snip returned by @racket[plot-snip].  When invoked, the mouse callback will
+add a @racket[vrule] at the current X position and a @racket[point-label] at
+the current value of the plotted function.
+
+@examples[#:eval plot-eval
+(require plot)
+(define snip (plot-snip (function sin) #:x-min -5 #:x-max 5))
+(define (mouse-callback snip event x y)
+   (if (and x y)
+       (send snip set-overlay-renderers (list (vrule x) (point-label (x (sin x)))))
+       (send snip set-overlay-renderers #f)))
+(send snip set-mouse-event-callback mouse-callback)
+snip]
+
+Here are a few hints for adding common interactive elements to racket plots:
+
+@itemlist[
+
+@item{@(racket hrule) and @(racket vrule) renderers can be used to draw
+horizontal and vertical lines that track the mouse position}
+
+@item{The @(racket rectangles) renderer can be used to highlight a region on
+the plot.  You can also specify @racket[-inf.0] and @racket[+inf.0] as limits
+for one of the dimensions, to extend the rectangle all the way to the edge of
+the plot in that direction.  You will need to specify a non zero value for the
+@racket[#:alpha] parameter, so the rectangle is transparent and the plot
+underneath it is visible. For example, to highlight a vertical region between
+@racket[xmin] and @racket[xmax], you can use:
+
+@racket[
+(rectangles (list (vector (ivl xmin xmax) (ivl -inf.0 +inf.0)))
+            #:alpha 0.2)]
+}
+
+@item{A @(racket point-label) renderer can be used to add a point with a
+string label to the plot.  To add only the label, use @racket['none] as the
+value for the @racket[#:point-sym] argument.}
+
+@item{A @(racket point-pict) renderer can be used to add a point with an
+attached @racketmodname[pict] instead of a string label.  This can be used to
+draw fancy labels (for example with rounded corners), or any other type of
+graphics element.}
+
+@item{A @(racket points) renderer can be used to mark specific locations on
+the plot, without specifying a label for them}
+]

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -893,56 +893,19 @@ Returns a renderer that draws a point with a pict as the label on a polar functi
 
 @section[#:tag "2d-plot-snip-interactive-overlays"]{Interactive Overlays for 2D plots}
 
-An plot object returned by @racket[plot-snip] can be set up to provide
-interactive overlays, such as displaying the current value of the plot
-function at the mouse cursor.  Two methods are available on the returned
-@racket[snip%] object for this purpose.
+@declare-exporting[plot/snip]
+@defmodule*/no-declare[(plot/snip)]
 
-@defclass[2d-plot-snip+c% snip% ()]{
+A plot @racket[snip%] object returned by @racket[plot-snip] can be set up to
+provide interactive overlays.  This feature can be used, for example, to show
+the current value of the plot function at the mouse cursor.
 
-An instance of this class is returned by @racket[plot-snip].
-
-@defmethod[(set-mouse-event-callback [callback (or/c plot-mouse-event-callback/c #f)]) any/c]{
-
-Set a callback function to be invoked with mouse events from the snip.  The
-callback is invoked with the actual snip object, the @racket[mouse-event%] and
-the X, Y position of the mouse in plot coordinates -- these are in the same
-coordinate system used by the renderers in the plot.  The X, Y values are
-@racket[#f] when the mouse is outside the plot area (for example, when the
-mouse is over the axis area).
-
-When a callback is installed, the default zoom functionality of the plot snips
-is disabled.  This can be restored by calling
-@racket[set-mouse-event-callback] with a @racket[#f] argument.
-
-}
-
-@defmethod[(set-overlay-renderers [renderers (or/c (treeof renderer2d?) #f)]) any/c]{
-
-Set a list of renderers (or more generally, a tree of renderers) to be drawn
-on top of the existing plot.  This can be any combination of 2D renderers, but
-it will not be able to modify the axes or the dimensions of the plot area.
-Only one set of overlay renderers can be installed, calling this method a
-second time will replace the previous overlays.  Specifying @racket[#f] as the
-renderers will cause overlays to be disabled.
-
-}
-}
-
-@defthing[plot-mouse-event-callback/c contract? #:value (-> (is-a?/c snip%)
-                                                       (is-a?/c mouse-event%)
-                                                       (or/c real? #f)
-                                                       (or/c real? #f) any/c)]{
-A contract for callback functions passed to @racket[set-mouse-event-callback].
-}
-
-
-For example, if you evaluate the code below in DrRacket, the resulting plot
-will show a vertical line tracking the mouse and the current plot position is
-shown on a label.  This is achieved by adding a mouse callback to the plot
-snip returned by @racket[plot-snip].  When invoked, the mouse callback will
-add a @racket[vrule] at the current X position and a @racket[point-label] at
-the current value of the plotted function.
+If the code below is evaluated in DrRacket, the resulting plot will show a
+vertical line tracking the mouse and the current plot position is shown on a
+label.  This is achieved by adding a mouse callback to the plot snip returned
+by @racket[plot-snip].  When the mouse callback is invoked, it will add a
+@racket[vrule] at the current X position and a @racket[point-label] at the
+current value of the plotted function.
 
 @racketblock[
 (require plot)
@@ -984,3 +947,42 @@ graphics element.}
 @item{A @(racket points) renderer can be used to mark specific locations on
 the plot, without specifying a label for them}
 ]
+
+@defclass[2d-plot-snip+c% snip% ()]{
+
+An instance of this class is returned by @racket[plot-snip].
+
+@defmethod[(set-mouse-event-callback [callback (or/c plot-mouse-event-callback/c #f)]) any/c]{
+
+Set a callback function to be invoked with mouse events from the snip.  The
+callback is invoked with the actual snip object, the @racket[mouse-event%] and
+the X, Y position of the mouse in plot coordinates -- these are in the same
+coordinate system used by the renderers in the plot.  The X, Y values are
+@racket[#f] when the mouse is outside the plot area (for example, when the
+mouse is over the axis area).
+
+When a callback is installed, the default zoom functionality of the plot snips
+is disabled.  This can be restored by calling
+@racket[set-mouse-event-callback] with a @racket[#f] argument.
+
+}
+
+@defmethod[(set-overlay-renderers [renderers (or/c (treeof renderer2d?) #f)]) any/c]{
+
+Set a list of renderers (or more generally, a tree of renderers) to be drawn
+on top of the existing plot.  This can be any combination of 2D renderers, but
+it will not be able to modify the axes or the dimensions of the plot area.
+Only one set of overlay renderers can be installed, calling this method a
+second time will replace the previous overlays.  Specifying @racket[#f] as the
+renderers will cause overlays to be disabled.
+
+}
+}
+
+@defthing[plot-mouse-event-callback/c contract? #:value (-> (is-a?/c snip%)
+                                                       (is-a?/c mouse-event%)
+                                                       (or/c real? #f)
+                                                       (or/c real? #f) any/c)]{
+A contract for callback functions passed to @racket[set-mouse-event-callback].
+}
+

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -898,7 +898,7 @@ interactive overlays, such as displaying the current value of the plot
 function at the mouse cursor.  Two methods are available on the returned
 @racket[snip%] object for this purpose.
 
-@defclass[2d-plot-snip% snip% ()]{
+@defclass[2d-plot-snip+c% snip% ()]{
 
 An instance of this class is returned by @racket[plot-snip].
 
@@ -949,7 +949,9 @@ the current value of the plotted function.
 (define snip (plot-snip (function sin) #:x-min -5 #:x-max 5))
 (define (mouse-callback snip event x y)
    (if (and x y)
-       (send snip set-overlay-renderers (list (vrule x) (point-label (x (sin x)))))
+       (send snip set-overlay-renderers
+             (list (vrule x)
+                   (point-label (vector x (sin x)))))
        (send snip set-overlay-renderers #f)))
 (send snip set-mouse-event-callback mouse-callback)
 snip]

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -895,7 +895,7 @@ Returns a renderer that draws a point with a pict as the label on a polar functi
 
 An plot object returned by @racket[plot-snip] can be set up to provide
 interactive overlays, such as displaying the current value of the plot
-function at he mouse cursor.  Two methods are available on the returned
+function at the mouse cursor.  Two methods are available on the returned
 @racket[snip%] object for this purpose.
 
 @defclass[2d-plot-snip% snip% ()]{
@@ -917,7 +917,7 @@ is disabled.  This can be restored by calling
 
 }
 
-@defmethod[(set-overlay-renderers [renderers (or/c #f (treeof renderer2d?))]) any/c]{
+@defmethod[(set-overlay-renderers [renderers (or/c (treeof renderer2d?) #f)]) any/c]{
 
 Set a list of renderers (or more generally, a tree of renderers) to be drawn
 on top of the existing plot.  This can be any combination of 2D renderers, but
@@ -944,7 +944,7 @@ snip returned by @racket[plot-snip].  When invoked, the mouse callback will
 add a @racket[vrule] at the current X position and a @racket[point-label] at
 the current value of the plotted function.
 
-@examples[#:eval plot-eval
+@racketblock[
 (require plot)
 (define snip (plot-snip (function sin) #:x-min -5 #:x-max 5))
 (define (mouse-callback snip event x y)
@@ -962,12 +962,8 @@ Here are a few hints for adding common interactive elements to racket plots:
 horizontal and vertical lines that track the mouse position}
 
 @item{The @(racket rectangles) renderer can be used to highlight a region on
-the plot.  You can also specify @racket[-inf.0] and @racket[+inf.0] as limits
-for one of the dimensions, to extend the rectangle all the way to the edge of
-the plot in that direction.  You will need to specify a non zero value for the
-@racket[#:alpha] parameter, so the rectangle is transparent and the plot
-underneath it is visible. For example, to highlight a vertical region between
-@racket[xmin] and @racket[xmax], you can use:
+the plot.  For example, to highlight a vertical region between @racket[xmin]
+and @racket[xmax], you can use:
 
 @racket[
 (rectangles (list (vector (ivl xmin xmax) (ivl -inf.0 +inf.0)))

--- a/plot-doc/plot/scribblings/renderer2d.scrbl
+++ b/plot-doc/plot/scribblings/renderer2d.scrbl
@@ -948,7 +948,7 @@ graphics element.}
 the plot, without specifying a label for them}
 ]
 
-@defclass[2d-plot-snip+c% snip% ()]{
+@defclass[2d-plot-snip% snip% ()]{
 
 An instance of this class is returned by @racket[plot-snip].
 

--- a/plot-gui-lib/plot/main.rkt
+++ b/plot-gui-lib/plot/main.rkt
@@ -2,7 +2,8 @@
 
 (require plot/no-gui
          "private/gui/plot2d.rkt"
-         "private/gui/plot3d.rkt")
+         "private/gui/plot3d.rkt"
+         "private/gui/snip2d.rkt")
 
 (provide (all-from-out plot/no-gui)
          plot-snip
@@ -10,4 +11,6 @@
          plot
          plot3d-snip
          plot3d-frame
-         plot3d)
+         plot3d
+         plot-mouse-event-callback/c
+         2d-plot-snip+c%)

--- a/plot-gui-lib/plot/main.rkt
+++ b/plot-gui-lib/plot/main.rkt
@@ -2,8 +2,7 @@
 
 (require plot/no-gui
          "private/gui/plot2d.rkt"
-         "private/gui/plot3d.rkt"
-         "private/gui/snip2d.rkt")
+         "private/gui/plot3d.rkt")
 
 (provide (all-from-out plot/no-gui)
          plot-snip
@@ -11,6 +10,4 @@
          plot
          plot3d-snip
          plot3d-frame
-         plot3d
-         plot-mouse-event-callback/c
-         2d-plot-snip+c%)
+         plot3d)

--- a/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
@@ -9,9 +9,10 @@
   (-> (Instance Bitmap%)
       Plot-Parameters
       (-> Boolean Rect Positive-Integer Positive-Integer
-          (Values (Instance Bitmap%) Rect (-> Rect Rect)))
+          (Values (Instance Bitmap%) (U #f (Instance 2D-Plot-Area%)) Rect (-> Rect Rect)))
       Rect
       Rect
+      (U #f (Instance 2D-Plot-Area%))
       (-> Rect Rect)
       Positive-Integer
       Positive-Integer

--- a/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
@@ -9,11 +9,9 @@
   (-> (Instance Bitmap%)
       Plot-Parameters
       (-> Boolean Rect Positive-Integer Positive-Integer
-          (Values (Instance Bitmap%) (U #f (Instance 2D-Plot-Area%)) Rect (-> Rect Rect)))
-      Rect
+          (Values (Instance Bitmap%) (U #f (Instance 2D-Plot-Area%))))
       Rect
       (U #f (Instance 2D-Plot-Area%))
-      (-> Rect Rect)
       Positive-Integer
       Positive-Integer
       (Instance Snip%)))

--- a/plot-gui-lib/plot/private/gui/lazy-snip-untyped.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-untyped.rkt
@@ -13,10 +13,10 @@
 
 (define (-make-2d-plot-snip
          init-bm saved-plot-parameters
-         make-bm plot-bounds-rect area-bounds-rect area area-bounds->plot-bounds width height)
+         make-bm plot-bounds-rect area width height)
   (make-2d-plot-snip
    init-bm saved-plot-parameters
-   make-bm plot-bounds-rect area-bounds-rect area area-bounds->plot-bounds width height))
+   make-bm plot-bounds-rect area width height))
 
 (define (-make-3d-plot-snip
          init-bm saved-plot-parameters

--- a/plot-gui-lib/plot/private/gui/lazy-snip-untyped.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-untyped.rkt
@@ -13,10 +13,10 @@
 
 (define (-make-2d-plot-snip
          init-bm saved-plot-parameters
-         make-bm plot-bounds-rect area-bounds-rect area-bounds->plot-bounds width height)
+         make-bm plot-bounds-rect area-bounds-rect area area-bounds->plot-bounds width height)
   (make-2d-plot-snip
    init-bm saved-plot-parameters
-   make-bm plot-bounds-rect area-bounds-rect area-bounds->plot-bounds width height))
+   make-bm plot-bounds-rect area-bounds-rect area area-bounds->plot-bounds width height))
 
 (define (-make-3d-plot-snip
          init-bm saved-plot-parameters

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -57,7 +57,7 @@
        (define bounds-rect (get-bounds-rect renderer-list x-min x-max y-min y-max))
        
        (: make-bm (-> Boolean Rect Positive-Integer Positive-Integer
-                      (Values (Instance Bitmap%) Rect (-> Rect Rect))))
+                      (Values (Instance Bitmap%) (U #f (Instance 2D-Plot-Area%)) Rect (-> Rect Rect))))
        (define (make-bm anim? bounds-rect width height)
          (: area (U #f (Instance 2D-Plot-Area%)))
          (define area #f)
@@ -91,14 +91,14 @@
                (match-define (vector x-max y-max) (send area dc->plot (vector area-x-max area-y-max)))
                (vector (ivl x-min x-max) (ivl y-min y-max)))))
          
-         (values bm (send (assert area values) get-area-bounds-rect) area-bounds->plot-bounds))
+         (values bm area (send (assert area values) get-area-bounds-rect) area-bounds->plot-bounds))
        
-       (define-values (bm area-bounds-rect area-bounds->plot-bounds)
+       (define-values (bm area area-bounds-rect area-bounds->plot-bounds)
          (make-bm #f bounds-rect width height))
        
        (make-2d-plot-snip
         bm saved-plot-parameters
-        make-bm bounds-rect area-bounds-rect area-bounds->plot-bounds width height))]))
+        make-bm bounds-rect area-bounds-rect area area-bounds->plot-bounds width height))]))
 
 ;; ===================================================================================================
 ;; Plot to a frame

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -57,7 +57,7 @@
        (define bounds-rect (get-bounds-rect renderer-list x-min x-max y-min y-max))
        
        (: make-bm (-> Boolean Rect Positive-Integer Positive-Integer
-                      (Values (Instance Bitmap%) (U #f (Instance 2D-Plot-Area%)) Rect (-> Rect Rect))))
+                      (Values (Instance Bitmap%) (U #f (Instance 2D-Plot-Area%)))))
        (define (make-bm anim? bounds-rect width height)
          (: area (U #f (Instance 2D-Plot-Area%)))
          (define area #f)
@@ -78,27 +78,11 @@
                                   
                                   (plot-area new-area renderer-list))
                                 width height)))
-         
-         (: area-bounds->plot-bounds (-> Rect Rect))
-         (define (area-bounds->plot-bounds rect)
-           (let ([area  (assert area values)])
-             (match-define (vector (ivl area-x-min area-x-max) (ivl area-y-min area-y-max)) rect)
-             (let ([area-x-min  (assert area-x-min values)]
-                   [area-x-max  (assert area-x-max values)]
-                   [area-y-min  (assert area-y-min values)]
-                   [area-y-max  (assert area-y-max values)])
-               (match-define (vector x-min y-min) (send area dc->plot (vector area-x-min area-y-min)))
-               (match-define (vector x-max y-max) (send area dc->plot (vector area-x-max area-y-max)))
-               (vector (ivl x-min x-max) (ivl y-min y-max)))))
-         
-         (values bm area (send (assert area values) get-area-bounds-rect) area-bounds->plot-bounds))
+         (values bm area))
        
-       (define-values (bm area area-bounds-rect area-bounds->plot-bounds)
-         (make-bm #f bounds-rect width height))
+       (define-values (bm area) (make-bm #f bounds-rect width height))
        
-       (make-2d-plot-snip
-        bm saved-plot-parameters
-        make-bm bounds-rect area-bounds-rect area area-bounds->plot-bounds width height))]))
+       (make-2d-plot-snip bm saved-plot-parameters make-bm bounds-rect area width height))]))
 
 ;; ===================================================================================================
 ;; Plot to a frame

--- a/plot-gui-lib/plot/private/gui/snip2d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip2d.rkt
@@ -182,7 +182,7 @@
       (refresh))
 
     (define (draw-overlay-renderers dc x y left top right bottom)
-      (when (list? the-overlay-renderers)
+      (when the-overlay-renderers
         ;; Implementation notes:
         ;;
         ;; * the `plot-area` routine used to draw plots, expects the origin of

--- a/plot-gui-lib/plot/private/gui/snip2d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip2d.rkt
@@ -15,7 +15,9 @@
          "worker-thread.rkt"
          "snip.rkt")
 
-(provide make-2d-plot-snip)
+(provide make-2d-plot-snip
+         plot-mouse-event-callback/c
+         2d-plot-snip+c%)
 
 (define update-delay 16)
 (define show-zoom-message? #t)

--- a/plot-gui-lib/plot/private/gui/snip2d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip2d.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require racket/gui/base racket/class racket/match racket/list racket/math
+(require racket/gui/base racket/class racket/contract racket/match racket/list racket/math
          plot/private/common/math
          plot/private/common/format
          plot/private/common/ticks
@@ -9,11 +9,13 @@
          plot/private/common/parameter-group
          plot/private/common/draw-attribs
          plot/private/plot2d/plot-area
+         plot/private/plot2d/renderer
          plot/private/no-gui/plot2d-utils
+         plot/private/common/contract
          "worker-thread.rkt"
          "snip.rkt")
 
-(provide 2d-plot-snip% make-2d-plot-snip)
+(provide make-2d-plot-snip)
 
 (define update-delay 16)
 (define show-zoom-message? #t)
@@ -352,9 +354,18 @@
       (super resize w h))
     ))
 
+(define plot-mouse-event-callback/c (-> (is-a?/c snip%) (is-a?/c mouse-event%)
+                                        (or/c real? #f) (or/c real? #f) any/c))
+
+(define/contract 2d-plot-snip+c%
+  (class/c
+   (set-mouse-event-callback (->m (or/c plot-mouse-event-callback/c #f) any/c))
+   (set-overlay-renderers (->m (or/c (treeof renderer2d?) #f) any/c)))
+  2d-plot-snip%)
+
 (define (make-2d-plot-snip
          init-bm saved-plot-parameters
          make-bm plot-bounds-rect area width height)
-  (make-object 2d-plot-snip%
+  (make-object 2d-plot-snip+c%
     init-bm saved-plot-parameters
     make-bm plot-bounds-rect area width height))

--- a/plot-gui-lib/plot/private/gui/snip2d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip2d.rkt
@@ -15,9 +15,18 @@
          "worker-thread.rkt"
          "snip.rkt")
 
-(provide make-2d-plot-snip
-         plot-mouse-event-callback/c
-         2d-plot-snip+c%)
+(define plot-mouse-event-callback/c
+  (-> (is-a?/c snip%) (is-a?/c mouse-event%) (or/c real? #f) (or/c real? #f) any/c))
+(define 2d-plot-snip+c%
+  (class/c
+   (set-mouse-event-callback (->m (or/c plot-mouse-event-callback/c #f) any/c))
+   (set-overlay-renderers (->m (or/c (treeof renderer2d?) #f) any/c))))
+
+(provide
+ (contract-out
+  (make-2d-plot-snip (unconstrained-domain-> (instanceof/c 2d-plot-snip+c%))))
+ 2d-plot-snip%
+ plot-mouse-event-callback/c)
 
 (define update-delay 16)
 (define show-zoom-message? #t)
@@ -356,18 +365,9 @@
       (super resize w h))
     ))
 
-(define plot-mouse-event-callback/c (-> (is-a?/c snip%) (is-a?/c mouse-event%)
-                                        (or/c real? #f) (or/c real? #f) any/c))
-
-(define/contract 2d-plot-snip+c%
-  (class/c
-   (set-mouse-event-callback (->m (or/c plot-mouse-event-callback/c #f) any/c))
-   (set-overlay-renderers (->m (or/c (treeof renderer2d?) #f) any/c)))
-  2d-plot-snip%)
-
 (define (make-2d-plot-snip
          init-bm saved-plot-parameters
          make-bm plot-bounds-rect area width height)
-  (make-object 2d-plot-snip+c%
+  (make-object 2d-plot-snip%
     init-bm saved-plot-parameters
     make-bm plot-bounds-rect area width height))

--- a/plot-gui-lib/plot/private/gui/snip2d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip2d.rkt
@@ -17,15 +17,15 @@
 
 (define plot-mouse-event-callback/c
   (-> (is-a?/c snip%) (is-a?/c mouse-event%) (or/c real? #f) (or/c real? #f) any/c))
-(define 2d-plot-snip+c%
+(define 2d-plot-snip%/c
   (class/c
    (set-mouse-event-callback (->m (or/c plot-mouse-event-callback/c #f) any/c))
    (set-overlay-renderers (->m (or/c (treeof renderer2d?) #f) any/c))))
 
 (provide
  (contract-out
-  (make-2d-plot-snip (unconstrained-domain-> (instanceof/c 2d-plot-snip+c%))))
- 2d-plot-snip%
+  [make-2d-plot-snip (unconstrained-domain-> (instanceof/c 2d-plot-snip%/c))]
+  [2d-plot-snip% 2d-plot-snip%/c])
  plot-mouse-event-callback/c)
 
 (define update-delay 16)

--- a/plot-gui-lib/plot/snip.rkt
+++ b/plot-gui-lib/plot/snip.rkt
@@ -4,4 +4,4 @@
 
 (provide
  plot-mouse-event-callback/c
- 2d-plot-snip+c%)
+ 2d-plot-snip%)

--- a/plot-gui-lib/plot/snip.rkt
+++ b/plot-gui-lib/plot/snip.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(require "private/gui/snip2d.rkt")
+
+(provide
+ plot-mouse-event-callback/c
+ 2d-plot-snip+c%)


### PR DESCRIPTION
Two methods are added to the 2d-plot-snip% (which is returned by the
`plot-snip` function):

* `set-mouse-event-callback` installs a user callback for handling mouse
  events from the plot snip.  The callback should be in the format:

  (lambda (snip mouse-event x y) ...)

  Where SNIP is the plot snip generating the event, MOUSE-EVENT is the event
  generated and X, Y are the location of the mouse in plot coordinates

* `set-overlay-renderers` adds a list of 2d renderers to be drawn on top of
  the plot.  This can be any valid 2d renderer.  Only one set of renderers is
  valid at a time, calling this function a second time, will replace the
  previous overlay renderers.  Calling the function with an #f argument will
  cause the overlay renderers to be removed.

Example usage:

```racket
#lang racket
(require plot pict)

(define fish (standard-fish 40 15 #:color "salmon"))

(define (on-hover snip event x y)
  (if (and x y)
      (let ((sx (sin x)))
        (send snip set-overlay-renderers
              (list (vrule x)
                    (hrule sx)
                    (point-label (vector x sx) "hello" #:anchor 'auto)
                    (point-pict (vector x y) fish #:anchor 'auto))))
      (send snip set-overlay-renderers #f)))

(define snip (plot-snip (function sin) #:x-min -10 #:x-max 10))
(send snip set-mouse-event-callback on-hover)
snip
```