### PR TITLE
Construct the plot snip with the right size for plot-frame #39

### DIFF
--- a/plot-gui-lib/plot/private/gui/gui.rkt
+++ b/plot-gui-lib/plot/private/gui/gui.rkt
@@ -16,9 +16,8 @@
     
     (super-new)))
 
-(define (make-snip-frame snip width height label)
-  (define (make-snip w h) snip)
-  
+(define (make-snip-frame make-snip width height label)
+
   (define frame
     (new snip-frame% [label label] [width (+ 20 width)] [height (+ 20 height)]))
   

--- a/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
@@ -28,7 +28,7 @@
       (Instance Snip%)))
 
 (define-type Make-Snip-Frame
-  (-> (Instance Snip%)
+  (-> (-> Positive-Integer Positive-Integer (Instance Snip%))
       Positive-Real
       Positive-Real
       String

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -130,12 +130,13 @@
     [(and y-min (not (rational? y-min)))  (fail/kw "#f or rational" '#:y-min y-min)]
     [(and y-max (not (rational? y-max)))  (fail/kw "#f or rational" '#:y-max y-max)]
     [else
-     (define snip
+     (: make-snip (-> Positive-Integer Positive-Integer (Instance Snip%)))
+     (define (make-snip width height)
        (plot-snip
         renderer-tree
         #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max #:width width #:height height
         #:title title #:x-label x-label #:y-label y-label #:legend-anchor legend-anchor))
-     (make-snip-frame snip width height (if title (format "Plot: ~a" title) "Plot"))]))
+     (make-snip-frame make-snip width height (if title (format "Plot: ~a" title) "Plot"))]))
 
 ;; ===================================================================================================
 ;; Plot to a frame or a snip, depending on (plot-new-window?)

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -151,14 +151,15 @@
     [(and y-max (not (rational? y-max)))  (fail/kw "#f or rational" '#:y-max y-max)]
     [(and z-min (not (rational? z-min)))  (fail/kw "#f or rational" '#:z-min z-min)]
     [(and z-max (not (rational? z-max)))  (fail/kw "#f or rational" '#:z-max z-max)])
-  
-  (define snip
+
+  (: make-snip (-> Positive-Integer Positive-Integer (Instance Snip%)))
+  (define (make-snip width height)
     (plot3d-snip
      renderer-tree
      #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max #:z-min z-min #:z-max z-max
      #:width width #:height height #:angle angle #:altitude altitude #:title title
      #:x-label x-label #:y-label y-label #:z-label z-label #:legend-anchor legend-anchor))
-  (make-snip-frame snip width height (if title (format "Plot: ~a" title) "Plot")))
+  (make-snip-frame make-snip width height (if title (format "Plot: ~a" title) "Plot")))
 
 ;; ===================================================================================================
 ;; Plot to a frame or a snip, depending on the value of plot-new-window?


### PR DESCRIPTION
The construction of the snip is delayed until its exact size is known by the
snip-canvas% that will hold it.