### PR TITLE
Add the ability to not call into collapse-ticks

### DIFF
--- a/plot-lib/plot/private/common/parameters.rkt
+++ b/plot-lib/plot/private/common/parameters.rkt
@@ -83,6 +83,8 @@
 (defparam plot-y-far-axis? Boolean #t)
 (defparam plot-z-far-axis? Boolean #t)
 
+(defparam collapse-ticks? Boolean #t)
+
 (defparam2 plot-x-tick-label-angle angle Real Real 0 (rational 'plot-x-tick-label-angle))
 (defparam2 plot-y-tick-label-angle angle Real Real 0 (rational 'plot-y-tick-label-angle))
 (defparam2 plot-x-far-tick-label-angle angle Real Real 0 (rational 'plot-x-far-tick-label-angle))

--- a/plot-lib/plot/private/plot2d/plot-area.rkt
+++ b/plot-lib/plot/private/plot2d/plot-area.rkt
@@ -262,21 +262,25 @@
     (: x-far-ticks (Listof tick))
     (: y-far-ticks (Listof tick))
     (define x-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= x-min (pre-tick-value t) x-max))
-                              (map tick-inexact->exact rx-ticks))
-                      (x-tick-near? y-min)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= x-min (pre-tick-value t) x-max))
+                                               (map tick-inexact->exact rx-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (x-tick-near? y-min))
+            exact-ticks-within-bounds)))
     (define x-far-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= x-min (pre-tick-value t) x-max))
-                              (map tick-inexact->exact rx-far-ticks))
-                      (x-tick-near? y-max)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= x-min (pre-tick-value t) x-max))
+                                               (map tick-inexact->exact rx-far-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (x-tick-near? y-max))
+            exact-ticks-within-bounds)))
     (define y-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= y-min (pre-tick-value t) y-max))
-                              (map tick-inexact->exact ry-ticks))
-                      (y-tick-near? x-min)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= y-min (pre-tick-value t) y-max))
+                                               (map tick-inexact->exact ry-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (y-tick-near? x-min))
+            exact-ticks-within-bounds)))
     (define y-far-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= y-min (pre-tick-value t) y-max))
-                              (map tick-inexact->exact ry-far-ticks))
-                      (y-tick-near? x-max)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= y-min (pre-tick-value t) y-max))
+                                               (map tick-inexact->exact ry-far-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (y-tick-near? x-max))
+            exact-ticks-within-bounds)))
 
     ;; ===============================================================================================
     ;; Tick and label parameters, and fixpoint margin computation

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -470,33 +470,39 @@
     (: y-ticks (Listof tick))
     (: z-ticks (Listof tick))
     (define x-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= x-min (pre-tick-value t) x-max))
-                              (map tick-inexact->exact rx-ticks))
-                      (x-ticks-near? x-axis-y)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= x-min (pre-tick-value t) x-max))
+                                               (map tick-inexact->exact rx-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (x-ticks-near? x-axis-y))
+            exact-ticks-within-bounds)))
     (define y-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= y-min (pre-tick-value t) y-max))
-                              (map tick-inexact->exact ry-ticks))
-                      (y-ticks-near? y-axis-x)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= y-min (pre-tick-value t) y-max))
+                                               (map tick-inexact->exact ry-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (y-ticks-near? y-axis-x))
+            exact-ticks-within-bounds)))
     (define z-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= z-min (pre-tick-value t) z-max))
-                              (map tick-inexact->exact rz-ticks))
-                      (z-ticks-near? z-axis-x z-axis-y)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= z-min (pre-tick-value t) z-max))
+                                               (map tick-inexact->exact rz-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (z-ticks-near? z-axis-x z-axis-y))
+            exact-ticks-within-bounds)))
     
     (: x-far-ticks (Listof tick))
     (: y-far-ticks (Listof tick))
     (: z-far-ticks (Listof tick))
     (define x-far-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= x-min (pre-tick-value t) x-max))
-                              (map tick-inexact->exact rx-far-ticks))
-                      (x-ticks-near? x-far-axis-y)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= x-min (pre-tick-value t) x-max))
+                                               (map tick-inexact->exact rx-far-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (x-ticks-near? x-far-axis-y))
+            exact-ticks-within-bounds)))
     (define y-far-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= y-min (pre-tick-value t) y-max))
-                              (map tick-inexact->exact ry-far-ticks))
-                      (y-ticks-near? y-far-axis-x)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= y-min (pre-tick-value t) y-max))
+                                               (map tick-inexact->exact ry-far-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (y-ticks-near? y-far-axis-x))
+            exact-ticks-within-bounds)))
     (define z-far-ticks
-      (collapse-ticks (filter (λ ([t : tick]) (<= z-min (pre-tick-value t) z-max))
-                              (map tick-inexact->exact rz-far-ticks))
-                      (z-ticks-near? z-far-axis-x z-far-axis-y)))
+      (let ([exact-ticks-within-bounds (filter (λ ([t : tick]) (<= z-min (pre-tick-value t) z-max))
+                                               (map tick-inexact->exact rz-far-ticks))])
+        (if (collapse-ticks?) (collapse-ticks exact-ticks-within-bounds (z-ticks-near? z-far-axis-x z-far-axis-y))
+            exact-ticks-within-bounds)))
     
     ;; ===============================================================================================
     ;; Tick and label parameters, and fixpoint margin computation

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -58,6 +58,7 @@
  plot-x-far-axis?
  plot-y-far-axis?
  plot-z-far-axis?
+ collapse-ticks?
  plot-x-tick-label-anchor
  plot-y-tick-label-anchor
  plot-x-far-tick-label-anchor


### PR DESCRIPTION
This is most helpful when trying to just have tick labels on the far y axis while keeping the ticks on the near y axis and allowing the grid to still be drawn. Here is the code that can be used for testing

```
#lang racket

(require plot)

(collapse-ticks? #t)

(parameterize ([plot-width    150]
                 [plot-height   150]
                 [plot-x-label  #f]
                 [plot-y-label  #f]
                 [plot-y-ticks (ticks (linear-ticks-layout) no-ticks-format)]
                 [plot-y-far-ticks (linear-ticks)])
    (plot (function sin (- pi) pi)))
```

By changing `collapse-ticks?` to `#f`, we can see all of the ticks on the near y axis and the `tick-grid` will also be displayed.