### PR TITLE
add arrows and arrows3d to allow plot arrows directly

### DIFF
--- a/plot-lib/plot/private/common/parameters.rkt
+++ b/plot-lib/plot/private/common/parameters.rkt
@@ -196,7 +196,9 @@
 (defparam vector-field-scale (U Real 'auto 'normalized) 'auto)
 (defparam2 vector-field-alpha Real Nonnegative-Real 1 (unit-ivl 'vector-field-alpha))
 (defparam vector-field3d-samples Positive-Integer 9)
-
+;;arrow
+(defparam arrow-head-size-scale Nonnegative 1)
+(defparam arrow-head-angle-scale Nonnegative 1)
 ;; Error bars
 
 (defparam2 error-bar-width Real Nonnegative-Real 6 (nonnegative-rational 'error-bar-width))

--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -394,7 +394,7 @@
                   (get-text-corners/anchor dc str x y anchor angle dist))]
             [else  empty]))
 
-    (define/public (draw-arrow v1 v2)
+    (define/public (draw-arrow v1 v2 [head-size-scale (arrow-head-size-scale)][head-angle-scale(arrow-head-size-scale)])
       (when (and (vrational? v1) (vrational? v2))
         (match-define (vector x1 y1) v1)
         (match-define (vector x2 y2) v2)
@@ -402,8 +402,8 @@
         (define dy (- y2 y1))
         (define angle (if (and (zero? dy) (zero? dx)) 0 (atan dy dx)))
         (define dist (sqrt (+ (sqr dx) (sqr dy))))
-        (define head-r (* 2/5 dist))
-        (define head-angle (* 1/6 pi))
+        (define head-r (* head-size-scale 2/5 dist))
+        (define head-angle (* head-angle-scale 1/6 pi))
         (define dx1 (* (cos (+ angle head-angle)) head-r))
         (define dy1 (* (sin (+ angle head-angle)) head-r))
         (define dx2 (* (cos (- angle head-angle)) head-r))

--- a/plot-lib/plot/private/plot2d/point.rkt
+++ b/plot-lib/plot/private/plot2d/point.rkt
@@ -146,7 +146,7 @@
     [else  empty]))
 
 (: arrows-render-fun
-   (-> (Sequenceof (Vector (Vectorof Real) (Vectorof Real)))
+   (-> (Listof (Vector (Vectorof Real) (Vectorof Real)))
         (U Real 'auto 'normalized)
        Plot-Color Nonnegative-Real Plot-Pen-Style
        Nonnegative-Real
@@ -165,8 +165,33 @@
                          (vector-ref x 1)
                          ))
                  (cond [label  (arrow-legend-entry label color line-width line-style)]
-                       [else   empty])])]
-    [else  empty]))
+                       [else   empty])]
+    [else  empty])
+  )
+
+(: arrows3d-render-fun
+   (-> (Listof (Vector (Vectorof Real) (Vectorof Real)))
+        (U Real 'auto 'normalized)
+       Plot-Color Nonnegative-Real Plot-Pen-Style
+       Nonnegative-Real
+       (U String #f)
+       3D-Render-Proc))
+(define ((arrows3d-render-fun vs scale color line-width line-style alpha label) area)
+  (match-define (vector (ivl x-min x-max) (ivl y-min y-max)(ivl z-min z-max)) (send area get-bounds-rect))
+  
+  (cond
+    [(and x-min x-max y-min y-max z-min z-max)  
+                 (send area put-alpha alpha)
+                 (send area put-pen color line-width line-style)
+                 (for ([x      (in-list vs)])
+                   (send area put-arrow
+                         (vector-ref x 0)
+                         (vector-ref x 1)
+                         ))
+                 (cond [label  (arrow-legend-entry label color line-width line-style)]
+                       [else   empty])]
+    [else  empty])
+  )
 (:: vector-field
     (->* [(U (-> Real Real (Sequenceof Real))
              (-> (Vector Real Real) (Sequenceof Real)))]

--- a/plot-lib/plot/private/plot2d/point.rkt
+++ b/plot-lib/plot/private/plot2d/point.rkt
@@ -145,6 +145,28 @@
                        [else   empty])])]
     [else  empty]))
 
+(: arrows-render-fun
+   (-> (Sequenceof (Vector (Vectorof Real) (Vectorof Real)))
+        (U Real 'auto 'normalized)
+       Plot-Color Nonnegative-Real Plot-Pen-Style
+       Nonnegative-Real
+       (U String #f)
+       2D-Render-Proc))
+(define ((arrows-render-fun vs scale color line-width line-style alpha label) area)
+  (match-define (vector (ivl x-min x-max) (ivl y-min y-max)) (send area get-bounds-rect))
+  
+  (cond
+    [(and x-min x-max y-min y-max)  
+                 (send area put-alpha alpha)
+                 (send area put-pen color line-width line-style)
+                 (for ([x      (in-list vs)])
+                   (send area put-arrow
+                         (vector-ref x 0)
+                         (vector-ref x 1)
+                         ))
+                 (cond [label  (arrow-legend-entry label color line-width line-style)]
+                       [else   empty])])]
+    [else  empty]))
 (:: vector-field
     (->* [(U (-> Real Real (Sequenceof Real))
              (-> (Vector Real Real) (Sequenceof Real)))]

--- a/plot-lib/plot/private/plot2d/point.rkt
+++ b/plot-lib/plot/private/plot2d/point.rkt
@@ -192,6 +192,113 @@
                        [else   empty])]
     [else  empty])
   )
+  (: get-min-max (-> (Pairof (Vector (Vectorof Real) (Vectorof Real)) (Listof (Vector (Vectorof Real) (Vectorof Real))))
+                   (values Real Real Real Real)))
+(define(get-min-max vs)
+  (define a0 (car vs))
+  (define a0-start (vector-ref a0 0))
+  (define a0-end (vector-ref a0 1))
+  (for/fold([x-min (min (vector-ref a0-start 0) (vector-ref a0-end 0))]
+            [y-min (min (vector-ref a0-start 1) (vector-ref a0-end 1))]
+            [x-max (max (vector-ref a0-start 0) (vector-ref a0-end 0))]
+            [y-max (max (vector-ref a0-start 1) (vector-ref a0-end 1))])
+           ([t (in-list (cdr vs))])
+    (define t-start (vector-ref t 0))
+    (define t-end (vector-ref t 1))
+    (values (min x-min (vector-ref t-start 0) (vector-ref t-end 0))
+            (min y-min (vector-ref t-start 1) (vector-ref t-end 1))
+            (max x-max (vector-ref t-start 0) (vector-ref t-end 0))
+            (max y-max (vector-ref t-start 1) (vector-ref t-end 1)))))
+
+(: get-min-max3d (-> (Pairof (Vector (Vectorof Real) (Vectorof Real)) (Listof (Vector (Vectorof Real) (Vectorof Real))))
+                   (values Real Real Real Real Real Real)))
+(define(get-min-max3d vs)
+  (define a0 (car vs))
+  (define a0-start (vector-ref a0 0))
+  (define a0-end (vector-ref a0 1))
+  (for/fold([x-min (min (vector-ref a0-start 0) (vector-ref a0-end 0))]
+            [y-min (min (vector-ref a0-start 1) (vector-ref a0-end 1))]
+            [z-min (min (vector-ref a0-start 2) (vector-ref a0-end 2))]
+            [x-max (max (vector-ref a0-start 0) (vector-ref a0-end 0))]
+            [y-max (max (vector-ref a0-start 1) (vector-ref a0-end 1))]
+            [z-max (max (vector-ref a0-start 2) (vector-ref a0-end 2))])
+           ([t (in-list (cdr vs))])
+    (define t-start (vector-ref t 0))
+    (define t-end (vector-ref t 1))
+    (values (min x-min (vector-ref t-start 0) (vector-ref t-end 0))
+            (min y-min (vector-ref t-start 1) (vector-ref t-end 1))
+            (min z-min (vector-ref t-start 2) (vector-ref t-end 2))
+            (max x-max (vector-ref t-start 0) (vector-ref t-end 0))
+            (max y-max (vector-ref t-start 1) (vector-ref t-end 1))
+            (max z-max (vector-ref t-start 2) (vector-ref t-end 2)))))
+                 
+
+
+(: arrows
+    (->* [(Pairof
+          (Vector (Vectorof Real) (Vectorof Real))(Listof (Vector (Vectorof Real) (Vectorof Real))))]
+         [
+          #:scale (U Real 'auto 'normalized)
+          #:color Plot-Color
+          #:line-width Nonnegative-Real
+          #:line-style Plot-Pen-Style
+          #:alpha Nonnegative-Real
+          #:label (U String #f)]
+         renderer2d))	 
+(define (arrows vs
+                        ;#:samples [samples (vector-field3d-samples)]
+                        #:scale [scale (vector-field-scale)]
+                        #:color [color (vector-field-color)]
+                        #:line-width [line-width (vector-field-line-width)]
+                        #:line-style [line-style (vector-field-line-style)]
+                        #:alpha [alpha (vector-field-alpha)]
+                        #:label [label #f])
+  (define fail/pos (make-raise-argument-error 'arrows vs))
+  (define fail/kw (make-raise-keyword-error 'arrows))
+  (cond
+    [(and (real? scale) (not (rational? scale)))
+     (fail/kw "'auto, 'normalized or rational" '#:scale scale)]
+    [(not (rational? line-width))  (fail/kw "rational?" '#:line-width line-width)]
+    [(or (> alpha 1) (not (rational? alpha)))  (fail/kw "real in [0,1]" '#:alpha alpha)]
+    [else
+    (define-values (x-min y-min  x-max y-max )
+      (get-min-max vs))
+       (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun
+                   (arrows-render-fun
+                    vs scale color line-width line-style alpha label))]))
+;--------------------------------2d-------------------------------------------------
+(: arrows3d
+    (->* [(Pairof
+          (Vector (Vectorof Real) (Vectorof Real))(Listof (Vector  (Vectorof Real)(Vectorof Real))))]
+         [
+          #:scale (U Real 'auto 'normalized)
+          #:color Plot-Color
+          #:line-width Nonnegative-Real
+          #:line-style Plot-Pen-Style
+          #:alpha Nonnegative-Real
+          #:label (U String #f)]
+         renderer3d))	 
+(define (arrows3d vs
+                        ;#:samples [samples (vector-field3d-samples)]
+                        #:scale [scale (vector-field-scale)]
+                        #:color [color (vector-field-color)]
+                        #:line-width [line-width (vector-field-line-width)]
+                        #:line-style [line-style (vector-field-line-style)]
+                        #:alpha [alpha (vector-field-alpha)]
+                        #:label [label #f])
+  (define fail/pos (make-raise-argument-error 'arrows vs))
+  (define fail/kw (make-raise-keyword-error 'arrows))
+  (cond
+    [(and (real? scale) (not (rational? scale)))
+     (fail/kw "'auto, 'normalized or rational" '#:scale scale)]
+    [(not (rational? line-width))  (fail/kw "rational?" '#:line-width line-width)]
+    [(or (> alpha 1) (not (rational? alpha)))  (fail/kw "real in [0,1]" '#:alpha alpha)]
+    [else
+    (define-values (x-min y-min z-min x-max y-max z-max)
+      (get-min-max3d vs))
+       (renderer3d (vector (ivl x-min x-max) (ivl y-min y-max) (ivl z-min z-max)) #f default-ticks-fun
+                   (arrows3d-render-fun
+                    vs scale color line-width line-style alpha label))]))
 (:: vector-field
     (->* [(U (-> Real Real (Sequenceof Real))
              (-> (Vector Real Real) (Sequenceof Real)))]


### PR DESCRIPTION
add arrows and arrows3d to allow plot arrows directly;
now,we can do:

#lang racket
(require plot)
(plot3d  (arrows3d (list (vector (vector 0 0 0)  (vector    1 1 1))))
             ))