### PR TITLE
add new params to control tick labels

### DIFF
--- a/plot-doc/plot/scribblings/params.scrbl
+++ b/plot-doc/plot/scribblings/params.scrbl
@@ -136,6 +136,16 @@ When any of these is @racket[#f], the corresponding axis is not drawn.
 Use these along with @racket[x-axis] and @racket[y-axis] renderers if you want axes that intersect the origin or some other point.
 }
 
+@deftogether[((defparam plot-x-tick-labels? draw? boolean? #:value #t)
+             (defparam plot-y-tick-labels? draw? boolean? #:value #t)
+             (defparam plot-z-tick-labels? draw? boolean? #:value #t)
+             (defparam plot-x-far-tick-labels? draw? boolean? #:value #f)
+             (defparam plot-y-far-tick-labels? draw? boolean? #:value #f)
+             (defparam plot-z-far-tick-labels? draw? boolean? #:value #f))]{
+When any of these is @racket[#f], the corresponding labels for the ticks on the axis are not drawn.
+These parameters work together with the parameters like @racket[plot-x-axis?] that control the drawing of the axes; i.e. tick labels won't be drawn unless the axis itself is drawn.
+}
+
 @defparam[plot-animating? animating? boolean? #:value #f]{
 When @(racket #t), certain renderers draw simplified plots to speed up drawing.
 @(plot-name) sets it to @(racket #t), for example, when a user is clicking and dragging a 3D plot to rotate it.

--- a/plot-lib/plot/private/common/parameter-groups.rkt
+++ b/plot-lib/plot/private/common/parameter-groups.rkt
@@ -12,12 +12,16 @@
                   plot-z-axis? plot-z-far-axis?))
   
   (define-parameter-group plot-tick-labels
-    (plot-x-tick-label-anchor
+    (plot-x-tick-labels?
+     plot-x-tick-label-anchor
      plot-x-tick-label-angle
+     plot-x-far-tick-labels?
      plot-x-far-tick-label-anchor
      plot-x-far-tick-label-angle
+     plot-y-tick-labels?
      plot-y-tick-label-anchor
      plot-y-tick-label-angle
+     plot-y-far-tick-labels?
      plot-y-far-tick-label-anchor
      plot-y-far-tick-label-angle))
   
@@ -89,7 +93,7 @@
       Anchor
       Nonnegative-Real
       (List Boolean Boolean Boolean Boolean Boolean Boolean)
-      (List Anchor Real Anchor Real Anchor Real Anchor Real)
+      (List Boolean Anchor Real Boolean Anchor Real Boolean Anchor Real Boolean Anchor Real)
       Boolean
       Boolean)
      (List Positive-Integer Real Real Nonnegative-Real Boolean Boolean)

--- a/plot-lib/plot/private/common/parameters.rkt
+++ b/plot-lib/plot/private/common/parameters.rkt
@@ -83,6 +83,14 @@
 (defparam plot-y-far-axis? Boolean #t)
 (defparam plot-z-far-axis? Boolean #t)
 
+(defparam plot-x-tick-labels? Boolean #t)
+(defparam plot-y-tick-labels? Boolean #t)
+(defparam plot-z-tick-labels? Boolean #t)
+
+(defparam plot-x-far-tick-labels? Boolean #f)
+(defparam plot-y-far-tick-labels? Boolean #f)
+(defparam plot-z-far-tick-labels? Boolean #f)
+
 (defparam2 plot-x-tick-label-angle angle Real Real 0 (rational 'plot-x-tick-label-angle))
 (defparam2 plot-y-tick-label-angle angle Real Real 0 (rational 'plot-y-tick-label-angle))
 (defparam2 plot-x-far-tick-label-angle angle Real Real 0 (rational 'plot-x-far-tick-label-angle))

--- a/plot-lib/plot/private/plot2d/plot-area.rkt
+++ b/plot-lib/plot/private/plot2d/plot-area.rkt
@@ -331,10 +331,14 @@
     ;; -----------------------------------------------------------------------------------------------
     ;; Tick label parameters
 
+    (: draw-x-tick-labels? Boolean)
+    (: draw-y-tick-labels? Boolean)
     (: draw-x-far-tick-labels? Boolean)
     (: draw-y-far-tick-labels? Boolean)
-    (define draw-x-far-tick-labels? (not (and (plot-x-axis?) (equal? x-ticks x-far-ticks))))
-    (define draw-y-far-tick-labels? (not (and (plot-y-axis?) (equal? y-ticks y-far-ticks))))
+    (define draw-x-tick-labels? (plot-x-tick-labels?))
+    (define draw-y-tick-labels? (plot-y-tick-labels?))
+    (define draw-x-far-tick-labels? (or (plot-x-far-tick-labels?) (not (and (plot-x-axis?) (equal? x-ticks x-far-ticks)))))
+    (define draw-y-far-tick-labels? (or (plot-y-far-tick-labels?) (not (and (plot-y-axis?) (equal? y-ticks y-far-ticks)))))
 
     (: x-tick-label-offset (Vectorof Real))
     (: y-tick-label-offset (Vectorof Real))
@@ -355,7 +359,7 @@
 
     (: get-x-tick-label-params (-> (Listof Label-Params)))
     (define (get-x-tick-label-params)
-      (if (and (plot-x-axis?) (plot-x-tick-labels?))
+      (if (and (plot-x-axis?) draw-x-tick-labels?)
           (get-tick-label-params x-ticks
                                  x-tick-label-offset
                                  (λ ([x : Real]) (x-tick-value->dc x))
@@ -365,7 +369,7 @@
 
     (: get-y-tick-label-params (-> (Listof Label-Params)))
     (define (get-y-tick-label-params)
-      (if (and (plot-y-axis?) (plot-y-tick-labels?))
+      (if (and (plot-y-axis?) draw-y-tick-labels?)
           (get-tick-label-params y-ticks
                                  y-tick-label-offset
                                  (λ ([y : Real]) (y-tick-value->dc y))
@@ -375,7 +379,7 @@
 
     (: get-x-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-x-far-tick-label-params)
-      (if (or (and (plot-x-far-axis?) draw-x-far-tick-labels?) (and (plot-x-far-axis?) (plot-x-far-tick-labels?)))
+      (if (and (plot-x-far-axis?) draw-x-far-tick-labels?)
           (get-tick-label-params x-far-ticks
                                  x-far-tick-label-offset
                                  (λ ([x : Real]) (x-far-tick-value->dc x))
@@ -385,7 +389,7 @@
 
     (: get-y-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-y-far-tick-label-params)
-      (if (or (and (plot-y-far-axis?) draw-y-far-tick-labels?) (and (plot-y-far-axis?) (plot-y-far-tick-labels?)))
+      (if (and (plot-y-far-axis?) draw-y-far-tick-labels?)
           (get-tick-label-params y-far-ticks
                                  y-far-tick-label-offset
                                  (λ ([y : Real]) (y-far-tick-value->dc y))
@@ -423,14 +427,14 @@
 
     (: max-x-tick-label-height Real)
     (define max-x-tick-label-height
-      (if (plot-x-axis?)
+      (if (and (plot-x-axis?) draw-x-tick-labels?)
           (apply max 0 (map (λ ([corner : (Vectorof Real)]) (vector-ref corner 1))
                             (get-relative-corners (get-x-tick-label-params))))
           0))
 
     (: max-y-tick-label-width Real)
     (define max-y-tick-label-width
-      (if (plot-y-axis?)
+      (if (and (plot-y-axis?) draw-y-tick-labels?)
           (- (apply min 0 (map (λ ([corner : (Vectorof Real)]) (vector-ref corner 0))
                                (get-relative-corners (get-y-tick-label-params)))))
           0))

--- a/plot-lib/plot/private/plot2d/plot-area.rkt
+++ b/plot-lib/plot/private/plot2d/plot-area.rkt
@@ -355,7 +355,7 @@
 
     (: get-x-tick-label-params (-> (Listof Label-Params)))
     (define (get-x-tick-label-params)
-      (if (plot-x-axis?)
+      (if (and (plot-x-axis?) (plot-x-tick-labels?))
           (get-tick-label-params x-ticks
                                  x-tick-label-offset
                                  (λ ([x : Real]) (x-tick-value->dc x))
@@ -365,7 +365,7 @@
 
     (: get-y-tick-label-params (-> (Listof Label-Params)))
     (define (get-y-tick-label-params)
-      (if (plot-y-axis?)
+      (if (and (plot-y-axis?) (plot-y-tick-labels?))
           (get-tick-label-params y-ticks
                                  y-tick-label-offset
                                  (λ ([y : Real]) (y-tick-value->dc y))
@@ -375,7 +375,7 @@
 
     (: get-x-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-x-far-tick-label-params)
-      (if (and (plot-x-far-axis?) draw-x-far-tick-labels?)
+      (if (or (and (plot-x-far-axis?) draw-x-far-tick-labels?) (and (plot-x-far-axis?) (plot-x-far-tick-labels?)))
           (get-tick-label-params x-far-ticks
                                  x-far-tick-label-offset
                                  (λ ([x : Real]) (x-far-tick-value->dc x))
@@ -385,7 +385,7 @@
 
     (: get-y-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-y-far-tick-label-params)
-      (if (and (plot-y-far-axis?) draw-y-far-tick-labels?)
+      (if (or (and (plot-y-far-axis?) draw-y-far-tick-labels?) (and (plot-y-far-axis?) (plot-y-far-tick-labels?)))
           (get-tick-label-params y-far-ticks
                                  y-far-tick-label-offset
                                  (λ ([y : Real]) (y-far-tick-value->dc y))

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -575,13 +575,19 @@
     
     ;; -----------------------------------------------------------------------------------------------
     ;; Tick label parameters
-    
+
+    (: draw-x-tick-labels? Boolean)
+    (: draw-y-tick-labels? Boolean)
+    (: draw-z-tick-labels? Boolean)
     (: draw-x-far-tick-labels? Boolean)
     (: draw-y-far-tick-labels? Boolean)
     (: draw-z-far-tick-labels? Boolean)
-    (define draw-x-far-tick-labels? (not (and (plot-x-axis?) (equal? x-ticks x-far-ticks))))
-    (define draw-y-far-tick-labels? (not (and (plot-y-axis?) (equal? y-ticks y-far-ticks))))
-    (define draw-z-far-tick-labels? (not (and (plot-z-axis?) (equal? z-ticks z-far-ticks))))
+    (define draw-x-tick-labels? (plot-x-tick-labels?))
+    (define draw-y-tick-labels? (plot-y-tick-labels?))
+    (define draw-z-tick-labels? (plot-z-tick-labels?))
+    (define draw-x-far-tick-labels? (or (plot-x-far-tick-labels?) (not (and (plot-x-axis?) (equal? x-ticks x-far-ticks)))))
+    (define draw-y-far-tick-labels? (or (plot-y-far-tick-labels?) (not (and (plot-y-axis?) (equal? y-ticks y-far-ticks)))))
+    (define draw-z-far-tick-labels? (or (plot-z-far-tick-labels?) (not (and (plot-z-axis?) (equal? z-ticks z-far-ticks)))))
     
     (: sort-ticks (-> (Listof tick) (-> Real FlVector) (Listof tick)))
     (define/private (sort-ticks ts tick-value->view)
@@ -627,7 +633,7 @@
     
     (: get-x-tick-label-params (-> (Listof Label-Params)))
     (define (get-x-tick-label-params)
-      (if (and (plot-x-axis?) (plot-x-tick-labels?))
+      (if (and (plot-x-axis?) draw-x-tick-labels?)
           (let ([offset  (if x-axis-y-min? (vneg (y-axis-dir)) (y-axis-dir))])
             (get-tick-label-params (sort-ticks x-ticks (λ ([x : Real]) (x-tick-value->view x)))
                                    (λ ([x : Real]) (x-tick-value->dc x))
@@ -637,7 +643,7 @@
     
     (: get-y-tick-label-params (-> (Listof Label-Params)))
     (define (get-y-tick-label-params)
-      (if (and (plot-y-axis?) (plot-y-tick-labels?))
+      (if (and (plot-y-axis?) draw-y-tick-labels?)
           (let ([offset  (if y-axis-x-min? (vneg (x-axis-dir)) (x-axis-dir))])
             (get-tick-label-params (sort-ticks y-ticks (λ ([y : Real]) (y-tick-value->view y)))
                                    (λ ([y : Real]) (y-tick-value->dc y))
@@ -647,7 +653,7 @@
     
     (: get-z-tick-label-params (-> (Listof Label-Params)))
     (define (get-z-tick-label-params)
-      (if (and (plot-z-axis?) (plot-z-tick-labels?))
+      (if (and (plot-z-axis?) draw-z-tick-labels?)
           (get-tick-label-params z-ticks
                                  (λ ([z : Real]) (z-tick-value->dc z))
                                  #(-1 0)
@@ -656,7 +662,7 @@
     
     (: get-x-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-x-far-tick-label-params)
-      (if (or (and (plot-x-far-axis?) draw-x-far-tick-labels?) (and (plot-x-far-axis?) (plot-x-far-tick-labels?)))
+      (if (and (plot-x-far-axis?) draw-x-far-tick-labels?)
           (let ([offset  (if x-axis-y-min? (y-axis-dir) (vneg (y-axis-dir)))])
             (get-tick-label-params (sort-ticks x-far-ticks (λ ([x : Real])
                                                              (x-far-tick-value->view x)))
@@ -667,7 +673,7 @@
     
     (: get-y-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-y-far-tick-label-params)
-      (if (or (and (plot-y-far-axis?) draw-y-far-tick-labels?) (and (plot-y-far-axis?) (plot-y-far-tick-labels?)))
+      (if (and (plot-y-far-axis?) draw-y-far-tick-labels?)
           (let ([offset  (if y-axis-x-min? (x-axis-dir) (vneg (x-axis-dir)))])
             (get-tick-label-params (sort-ticks y-far-ticks (λ ([y : Real])
                                                              (y-far-tick-value->view y)))
@@ -678,7 +684,7 @@
     
     (: get-z-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-z-far-tick-label-params)
-      (if (or (and (plot-z-far-axis?) draw-z-far-tick-labels?) (and (plot-z-far-axis?) (plot-z-far-tick-labels?)))
+      (if (and (plot-z-far-axis?) draw-z-far-tick-labels?)
           (get-tick-label-params z-far-ticks
                                  (λ ([z : Real]) (z-far-tick-value->dc z))
                                  #(1 0)
@@ -745,13 +751,13 @@
     
     (: max-x-tick-label-diag (-> Real))
     (define (max-x-tick-label-diag)
-      (if (plot-x-axis?)
+      (if (and (plot-x-axis?) draw-x-tick-labels?)
           (max-tick-label-diag (y-axis-dir) max-x-tick-label-width max-x-tick-label-height)
           0))
     
     (: max-y-tick-label-diag (-> Real))
     (define (max-y-tick-label-diag)
-      (if (plot-y-axis?)
+      (if (and (plot-y-axis?) draw-y-far-tick-labels?)
           (max-tick-label-diag (x-axis-dir) max-y-tick-label-width max-y-tick-label-height)
           0))
     

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -627,7 +627,7 @@
     
     (: get-x-tick-label-params (-> (Listof Label-Params)))
     (define (get-x-tick-label-params)
-      (if (plot-x-axis?)
+      (if (and (plot-x-axis?) (plot-x-tick-labels?))
           (let ([offset  (if x-axis-y-min? (vneg (y-axis-dir)) (y-axis-dir))])
             (get-tick-label-params (sort-ticks x-ticks (λ ([x : Real]) (x-tick-value->view x)))
                                    (λ ([x : Real]) (x-tick-value->dc x))
@@ -637,7 +637,7 @@
     
     (: get-y-tick-label-params (-> (Listof Label-Params)))
     (define (get-y-tick-label-params)
-      (if (plot-y-axis?)
+      (if (and (plot-y-axis?) (plot-y-tick-labels?))
           (let ([offset  (if y-axis-x-min? (vneg (x-axis-dir)) (x-axis-dir))])
             (get-tick-label-params (sort-ticks y-ticks (λ ([y : Real]) (y-tick-value->view y)))
                                    (λ ([y : Real]) (y-tick-value->dc y))
@@ -647,7 +647,7 @@
     
     (: get-z-tick-label-params (-> (Listof Label-Params)))
     (define (get-z-tick-label-params)
-      (if (plot-z-axis?)
+      (if (and (plot-z-axis?) (plot-z-tick-labels?))
           (get-tick-label-params z-ticks
                                  (λ ([z : Real]) (z-tick-value->dc z))
                                  #(-1 0)
@@ -656,7 +656,7 @@
     
     (: get-x-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-x-far-tick-label-params)
-      (if (and (plot-x-far-axis?) draw-x-far-tick-labels?)
+      (if (or (and (plot-x-far-axis?) draw-x-far-tick-labels?) (and (plot-x-far-axis?) (plot-x-far-tick-labels?)))
           (let ([offset  (if x-axis-y-min? (y-axis-dir) (vneg (y-axis-dir)))])
             (get-tick-label-params (sort-ticks x-far-ticks (λ ([x : Real])
                                                              (x-far-tick-value->view x)))
@@ -667,7 +667,7 @@
     
     (: get-y-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-y-far-tick-label-params)
-      (if (and (plot-y-far-axis?) draw-y-far-tick-labels?)
+      (if (or (and (plot-y-far-axis?) draw-y-far-tick-labels?) (and (plot-y-far-axis?) (plot-y-far-tick-labels?)))
           (let ([offset  (if y-axis-x-min? (x-axis-dir) (vneg (x-axis-dir)))])
             (get-tick-label-params (sort-ticks y-far-ticks (λ ([y : Real])
                                                              (y-far-tick-value->view y)))
@@ -678,7 +678,7 @@
     
     (: get-z-far-tick-label-params (-> (Listof Label-Params)))
     (define (get-z-far-tick-label-params)
-      (if (and (plot-z-far-axis?) draw-z-far-tick-labels?)
+      (if (or (and (plot-z-far-axis?) draw-z-far-tick-labels?) (and (plot-z-far-axis?) (plot-z-far-tick-labels?)))
           (get-tick-label-params z-far-ticks
                                  (λ ([z : Real]) (z-far-tick-value->dc z))
                                  #(1 0)

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -58,6 +58,12 @@
  plot-x-far-axis?
  plot-y-far-axis?
  plot-z-far-axis?
+ plot-x-tick-labels?
+ plot-y-tick-labels?
+ plot-z-tick-labels?
+ plot-x-far-tick-labels?
+ plot-y-far-tick-labels?
+ plot-z-far-tick-labels?
  plot-x-tick-label-anchor
  plot-y-tick-label-anchor
  plot-x-far-tick-label-anchor


### PR DESCRIPTION
This uses a different approach to showing ticks but hiding labels using feedback from @bennn and @alex-hhh on PR #41 

This was tested with the following code:
```
#lang racket

(require plot)

(parameterize ([plot-width    150]
                 [plot-height   150]
                 [plot-x-label  #f]
                 [plot-y-label  #f]
                 [plot-y-tick-labels? #f]
                 [plot-y-far-tick-labels? #t])
    (plot (function sin (- pi) pi)))
```
This will produce:
![sin-no-labels](https://user-images.githubusercontent.com/1124030/39089014-b766f7da-4558-11e8-8db9-569e69997197.png)
I suppose some documentation will be nice here even though this seems much more straight forward.