### PR TITLE
Capture plot parameters in plot-frame and plot3d-frame

### DIFF
--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -114,13 +114,17 @@
     [(and y-min (not (rational? y-min)))  (fail/kw "#f or rational" '#:y-min y-min)]
     [(and y-max (not (rational? y-max)))  (fail/kw "#f or rational" '#:y-max y-max)]
     [else
+     ;; make-snip will be called in a separate thread, make sure the
+     ;; parameters have the correct values in that thread as well.
+     (define saved-plot-parameters (plot-parameters))
      (: make-snip (-> Positive-Integer Positive-Integer (Instance Snip%)))
      (define (make-snip width height)
-       (plot-snip
-        renderer-tree
-        #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max #:width width #:height height
-        #:title title #:x-label x-label #:y-label y-label #:legend-anchor legend-anchor))
-     (make-snip-frame make-snip width height (if title (format "Plot: ~a" title) "Plot"))]))
+       (parameterize/group ([plot-parameters  saved-plot-parameters])
+         (plot-snip
+          renderer-tree
+          #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max #:width width #:height height
+          #:title title #:x-label x-label #:y-label y-label #:legend-anchor legend-anchor)))
+           (make-snip-frame make-snip width height (if title (format "Plot: ~a" title) "Plot"))]))
 
 ;; ===================================================================================================
 ;; Plot to a frame or a snip, depending on (plot-new-window?)

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -152,13 +152,17 @@
     [(and z-min (not (rational? z-min)))  (fail/kw "#f or rational" '#:z-min z-min)]
     [(and z-max (not (rational? z-max)))  (fail/kw "#f or rational" '#:z-max z-max)])
 
+  ;; make-snip will be called in a separate thread, make sure the
+  ;; parameters have the correct values in that thread as well.
+  (define saved-plot-parameters (plot-parameters))
   (: make-snip (-> Positive-Integer Positive-Integer (Instance Snip%)))
   (define (make-snip width height)
-    (plot3d-snip
-     renderer-tree
-     #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max #:z-min z-min #:z-max z-max
-     #:width width #:height height #:angle angle #:altitude altitude #:title title
-     #:x-label x-label #:y-label y-label #:z-label z-label #:legend-anchor legend-anchor))
+    (parameterize/group ([plot-parameters  saved-plot-parameters])
+      (plot3d-snip
+       renderer-tree
+       #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max #:z-min z-min #:z-max z-max
+       #:width width #:height height #:angle angle #:altitude altitude #:title title
+       #:x-label x-label #:y-label y-label #:z-label z-label #:legend-anchor legend-anchor)))
   (make-snip-frame make-snip width height (if title (format "Plot: ~a" title) "Plot")))
 
 ;; ===================================================================================================


### PR DESCRIPTION
`plot-frame` and `plot3d-frame` delays the creation of the plot snip object until the size of the canvas is known.  This means that the snip creation code is executed outside any `parameterize` scope and the values of any plot parameters (like `plot-decorations?`) would be ignored unless they are saved using `plot-parameters` and restored using `parameterize/group`

The fix is based on a problem reported here: https://groups.google.com/forum/#!topic/racket-users/ta-245wAYco

The issue was introduced when #39 was fixed, since at that time the plot snip was no longer created withing the scope of the `parameterize` call.

Here is some example code to test this (previously the two plots would have decorations, even though `plot-decorations?` is `#f):

```racket
#lang racket
(require plot)

(plot-new-window? #t)

(parameterize ((plot-decorations? #f))
  (plot3d (surface3d (λ (x y) (* (cos x) (sin y)))
                     -3.0 3.0 -3.0 3.0)))

(parameterize ((plot-decorations? #f))
  (plot (function sin) #:x-min -3 #:x-max 3))
```