### PR TITLE
Use platform specific bitmaps for rendering plots, where applicable

### DIFF
--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket/base
 
 (require (only-in typed/mred/mred Snip% Frame%)
-         (only-in racket/gui/base make-screen-bitmap)
+         (only-in racket/gui/base get-display-backing-scale)
          typed/racket/draw typed/racket/class racket/match
          plot/utils
          plot/private/common/parameter-group
@@ -62,7 +62,9 @@
        (define (make-bm anim? bounds-rect width height)
          (: area (U #f (Instance 2D-Plot-Area%)))
          (define area #f)
-         (define bm (make-screen-bitmap width height))
+         (define bm (make-bitmap
+                     width height #t
+                     #:backing-scale (or (get-display-backing-scale) 1.0)))
          (parameterize/group ([plot-parameters  saved-plot-parameters]
                               [plot-animating?  (if anim? #t (plot-animating?))])
            (define dc (make-object bitmap-dc% bm))

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -1,6 +1,7 @@
 #lang typed/racket/base
 
 (require (only-in typed/mred/mred Snip% Frame%)
+         (only-in racket/gui/base make-screen-bitmap)
          typed/racket/draw typed/racket/class racket/match racket/list
          plot/utils
          plot/private/common/parameter-group
@@ -78,36 +79,36 @@
                            [plot-animating?  (if anim? #t (plot-animating?))]
                            [plot3d-angle     angle]
                            [plot3d-altitude  altitude])
-        ((if (plot-animating?) draw-bitmap draw-bitmap/supersampling)
-         (λ (dc)
-           (define area (make-object 3d-plot-area%
-                          bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks z-ticks z-far-ticks
-                          dc 0 0 width height))
-           (send area start-plot)
+        (define bm (make-screen-bitmap width height))
+        (define dc (make-object bitmap-dc% bm))
+        (define area (make-object 3d-plot-area%
+                                  bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks z-ticks z-far-ticks
+                                  dc 0 0 width height))
+        (send area start-plot)
            
-           (cond [(not (hash-ref render-tasks-hash (plot-animating?) #f))
-                  (hash-set!
-                   legend-entries-hash (plot-animating?)
-                   (flatten-legend-entries
-                    (for/list : (Listof (Treeof legend-entry)) ([rend  (in-list renderer-list)])
-                      (match-define (renderer3d rend-bounds-rect _bf _tf render-proc) rend)
-                      (send area start-renderer (if rend-bounds-rect
-                                                    (rect-inexact->exact rend-bounds-rect)
-                                                    (unknown-rect 3)))
-                      (if render-proc (render-proc area) empty))))
-                  
-                  (hash-set! render-tasks-hash (plot-animating?) (send area get-render-tasks))]
-                 [else
-                  (send area set-render-tasks (hash-ref render-tasks-hash (plot-animating?)))])
+        (cond [(not (hash-ref render-tasks-hash (plot-animating?) #f))
+               (hash-set!
+                legend-entries-hash (plot-animating?)
+                (flatten-legend-entries
+                 (for/list : (Listof (Treeof legend-entry)) ([rend  (in-list renderer-list)])
+                   (match-define (renderer3d rend-bounds-rect _bf _tf render-proc) rend)
+                   (send area start-renderer (if rend-bounds-rect
+                                                 (rect-inexact->exact rend-bounds-rect)
+                                                 (unknown-rect 3)))
+                   (if render-proc (render-proc area) empty))))
+               
+               (hash-set! render-tasks-hash (plot-animating?) (send area get-render-tasks))]
+              [else
+               (send area set-render-tasks (hash-ref render-tasks-hash (plot-animating?)))])
            
-           (send area end-renderers)
-           
-           (define legend-entries (hash-ref legend-entries-hash (plot-animating?) #f))
-           (when (and legend-entries (not (empty? legend-entries)))
-             (send area draw-legend legend-entries))
-           
-           (send area end-plot))
-         width height)))
+        (send area end-renderers)
+        
+        (define legend-entries (hash-ref legend-entries-hash (plot-animating?) #f))
+        (when (and legend-entries (not (empty? legend-entries)))
+          (send area draw-legend legend-entries))
+        
+        (send area end-plot)
+        bm))
     
     (make-3d-plot-snip
      (make-bm #f angle altitude width height) saved-plot-parameters

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket/base
 
 (require (only-in typed/mred/mred Snip% Frame%)
-         (only-in racket/gui/base make-screen-bitmap)
+         (only-in racket/gui/base get-display-backing-scale)
          typed/racket/draw typed/racket/class racket/match racket/list
          plot/utils
          plot/private/common/parameter-group
@@ -79,7 +79,9 @@
                            [plot-animating?  (if anim? #t (plot-animating?))]
                            [plot3d-angle     angle]
                            [plot3d-altitude  altitude])
-        (define bm (make-screen-bitmap width height))
+        (define bm (make-bitmap
+                     width height #t
+                     #:backing-scale (or (get-display-backing-scale) 1.0)))
         (define dc (make-object bitmap-dc% bm))
         (define area (make-object 3d-plot-area%
                                   bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks z-ticks z-far-ticks

--- a/plot-lib/plot/private/common/draw.rkt
+++ b/plot-lib/plot/private/common/draw.rkt
@@ -429,23 +429,3 @@
                   (define scale (max 1.0 (fl (send pen get-width))))
                   (define sty (scale-pen-style (symbol->style style-sym) scale))
                   (draw-lines* dc vs sty)]))]))
-
-;; ===================================================================================================
-;; Drawing a bitmap using 2x supersampling
-
-(: draw-bitmap/supersampling (-> (-> (Instance DC<%>) Any) Positive-Integer Positive-Integer
-                                 (Instance Bitmap%)))
-(define (draw-bitmap/supersampling draw width height)
-  (define bm (make-bitmap width height #:backing-scale 2))
-  (define dc (make-object bitmap-dc% bm))
-  (send dc set-alignment-scale 2)
-  (draw dc)
-  bm)
-
-(: draw-bitmap (-> (-> (Instance DC<%>) Any) Positive-Integer Positive-Integer
-                   (Instance Bitmap%)))
-(define (draw-bitmap draw width height)
-  (define bm (make-bitmap width height))
-  (define dc (make-object bitmap-dc% bm))
-  (draw dc)
-  bm)

--- a/plot-lib/plot/private/no-gui/plot2d.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d.rkt
@@ -91,12 +91,12 @@
                      #:x-label [x-label (plot-x-label)]
                      #:y-label [y-label (plot-y-label)]
                      #:legend-anchor [legend-anchor (plot-legend-anchor)])
-  ((if (plot-animating?) draw-bitmap draw-bitmap/supersampling)
-   (λ (dc) 
-     (plot/dc renderer-tree dc 0 0 width height
-              #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max
-              #:title title #:x-label x-label #:y-label y-label #:legend-anchor legend-anchor))
-   width height))
+  (define bm (make-bitmap width height))
+  (define dc (make-object bitmap-dc% bm))
+  (plot/dc renderer-tree dc 0 0 width height
+           #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max
+           #:title title #:x-label x-label #:y-label y-label #:legend-anchor legend-anchor)
+  bm)
 
 ;; ===================================================================================================
 ;; Plot to a pict

--- a/plot-lib/plot/private/no-gui/plot3d.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d.rkt
@@ -121,13 +121,13 @@
                        #:y-label [y-label (plot-y-label)]
                        #:z-label [z-label (plot-z-label)]
                        #:legend-anchor [legend-anchor (plot-legend-anchor)])
-  ((if (plot-animating?) draw-bitmap draw-bitmap/supersampling)
-   (λ (dc)
-     (plot3d/dc renderer-tree dc 0 0 width height
-                #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max #:z-min z-min #:z-max z-max
-                #:angle angle #:altitude altitude #:title title #:x-label x-label #:y-label y-label
-                #:z-label z-label #:legend-anchor legend-anchor))
-   width height))
+  (define bm (make-bitmap width height))
+  (define dc (make-object bitmap-dc% bm))
+  (plot3d/dc renderer-tree dc 0 0 width height
+             #:x-min x-min #:x-max x-max #:y-min y-min #:y-max y-max #:z-min z-min #:z-max z-max
+             #:angle angle #:altitude altitude #:title title #:x-label x-label #:y-label y-label
+             #:z-label z-label #:legend-anchor legend-anchor)
+  bm)
 
 ;; ===================================================================================================
 ;; Plot to a pict


### PR DESCRIPTION
The 2D and 3D plot commands from the "no-gui" library have been updated to use
`make-bitmap`, while the corresponding commands from the GUI library have been
now use `make-platform-bitmap`.

`make-platform-bitmap` will create a bitmap optimized for being displayed on
the screen, with the correct backing scale for the monitor -- the
`draw-bitmap/supersampling` always used a backing scale of 2 which resulted in
blurred text for non-HiDPI screens, also Windows uses a backing scale of 1.5
by default on HiDPI displays.

The non-gui plot commands were already using `make-bitmap` via a call to
`draw-bitmap` but `draw-bitmap` and `draw-bitmap/supersampling` have been
removed from "draw.rkt", as they were no longer used, and they were not
providing much abstraction anyway -- also `make-platform-bitmap` is only
available in the GUI library.