### PR TITLE
Add color map support for selecting colors for renderers

### DIFF
--- a/plot-doc/plot/scribblings/common.rkt
+++ b/plot-doc/plot/scribblings/common.rkt
@@ -42,3 +42,33 @@
 
 (define (close-plot-eval)
   (close-eval plot-eval))
+
+(require plot plot/utils pict racket/match racket/class racket/draw)
+(define (pretty-print-color-maps (width 400) (height 30))
+  (define cm-names
+    (sort (color-map-names)
+          (lambda (a b)
+            (string<=? (symbol->string a) (symbol->string b)))))
+  (define cm-labels
+    (for/list ([cm cm-names])
+      (text (symbol->string cm) null 16)))
+  (define cm-picts
+    (for/list ([cm cm-names])
+      (parameterize ([plot-pen-color-map cm])
+        (define w (/ width (color-map-size cm)))
+        (apply
+         hc-append 0
+         (for/list ([c (in-range (color-map-size cm))])
+           (match-define (list r g b) (->pen-color c))
+           (define color (make-object color% r g b))
+           (filled-rectangle w height #:draw-border? #f #:color color))))))
+  (define picts
+    (let loop ([result '()]
+               [labels cm-labels]
+               [picts cm-picts])
+      (if (null? labels)
+          (reverse result)
+          (loop (cons (car picts) (cons (car labels) result))
+                (cdr labels)
+                (cdr picts)))))
+  (table 2 picts lc-superimpose cc-superimpose 15 3))

--- a/plot-doc/plot/scribblings/params.scrbl
+++ b/plot-doc/plot/scribblings/params.scrbl
@@ -161,6 +161,32 @@ This returns @racket[samples] when @racket[plot-animating?] is @racket[#f].
 When @(racket #f), axes, axis labels, ticks, tick labels, and the title are not drawn.
 }
 
+@deftogether[((defparam plot-pen-color-map name (or/c symbol? #f) #:value #f)
+              (defparam plot-brush-color-map name (or/c symbol? #f) #:value #f))]{
+
+Specify the color maps to be used by @racket[->pen-color] and
+@racket[->brush-color] respectively, for converting integer values into RGB
+triplets, or when integer values are used with the @racket[#:color] keyword of
+various plot renderers.  You can determine the list of available color map
+names using @racket[color-map-names].
+
+If @racket[name] is not a valid color map name, the internal color map will be
+used, this is the same as specifying @racket[#f].
+
+When the color map value is set to @racket[#f], internal color maps will be
+used, one for pen and one for brush colors.  The internal color map used for
+pen colors has darker and more saturated colors than the one used for brush
+colors.  These colors are chosen for good pairwise contrast, especially
+between neighbors and they repeat starting with @(racket 128).
+
+The color maps available by default are shown below and additional ones can be
+added using @racket[register-color-map]:
+
+@centered{@(pretty-print-color-maps)}
+
+}
+
+
 @section{Lines}
 
 @defparam[line-samples n (and/c exact-integer? (>=/c 2)) #:value 500]{

--- a/plot-doc/plot/scribblings/utils.scrbl
+++ b/plot-doc/plot/scribblings/utils.scrbl
@@ -190,11 +190,11 @@ Use @(racket ->pen-color) and @(racket ->brush-color) to convert integers.
 }
 
 @defproc[(->pen-color [c plot-color/c]) (list/c real? real? real?)]{
-Converts a @italic{line} color to an RGB triplet. This function interprets integer colors as darker and more saturated than @(racket ->brush-color) does.
 
-Non-integer colors are converted using @(racket ->color).
-Integer colors are chosen for good pairwise contrast, especially between neighbors.
-Integer colors repeat starting with @(racket 128).
+Convert a @italic{line} color to an RGB triplet. Integer colors are looked up
+in the current @racket[plot-pen-color-map], and non-integer colors are
+converted using @(racket ->color).  When the integer color is larger than the
+number of colors in the color map, it will wrap around.
 
 @examples[#:eval plot-eval
                  (equal? (->pen-color 0) (->pen-color 8))
@@ -204,12 +204,15 @@ Integer colors repeat starting with @(racket 128).
                         #:colors (map ->pen-color (build-list 8 values))))]
 }
 
-@defproc[(->brush-color [c plot-color/c]) (list/c real? real? real?)]{
-Converts a @italic{fill} color to an RGB triplet. This function interprets integer colors as lighter and less saturated than @(racket ->pen-color) does.
+The example above is using the internal color map, with
+@racket[plot-pen-color-map] set to @racket[#f].
 
-Non-integer colors are converted using @(racket ->color).
-Integer colors are chosen for good pairwise contrast, especially between neighbors.
-Integer colors repeat starting with @(racket 128).
+@defproc[(->brush-color [c plot-color/c]) (list/c real? real? real?)]{
+
+Convert a @italic{fill} color to an RGB triplet.  Integer colors are looked up
+in the current @racket[plot-brush-color-map] and non-integer colors are
+converted using @(racket ->color).  When the integer color is larger than the
+number of colors in the color map, it will wrap around.
 
 @examples[#:eval plot-eval
                  (equal? (->brush-color 0) (->brush-color 8))
@@ -218,7 +221,11 @@ Integer colors repeat starting with @(racket 128).
                         #:levels 7 #:contour-styles '(transparent)
                         #:colors (map ->brush-color (build-list 8 values))))]
 
-In the above example, @(racket map)ping @(racket ->brush-color) over the list is actually unnecessary, because @(racket contour-intervals) uses @(racket ->brush-color) internally to convert fill colors.
+The example above is using the internal color map, with
+@racket[plot-brush-color-map] is set to @racket[#f]. In this example, @(racket
+map)ping @(racket ->brush-color) over the list is actually unnecessary,
+because @(racket contour-intervals) uses @(racket ->brush-color) internally to
+convert fill colors.
 
 The @(racket function-interval) function generally plots areas using a fill color and lines using a line color.
 Both kinds of color have the default value @(racket 3).
@@ -250,6 +257,28 @@ Integer brush styles repeat starting at @(racket 7).
                  (map ->brush-style '(0 1 2 3))
                  (map ->brush-style '(4 5 6))]
 }
+
+@defproc[(color-map-names) (listof symbol?)]{
+
+Return the list of available color map names to be used by
+@racket[plot-pen-color-map] and @racket[plot-brush-color-map].
+
+}
+
+@defproc[(color-map-size (name symbol?)) integer?]{
+
+Return the number of colors in the color map @racket[name].  If @racket[name]
+is not a valid color map name, the function will signal an error.
+
+}
+
+@defproc[(register-color-map (name symbol?) (color-map (vectorof (list byte? byte? byte?)))) void]{
+
+Register a new color map @racket[name] with the colors being a vector of RGB
+triplets.  If a color map by that name already exists, it is replaced.
+
+}
+
 
 @;====================================================================================================
 @section{Plot-Specific Math}

--- a/plot-gui-lib/plot/private/gui/snip.rkt
+++ b/plot-gui-lib/plot/private/gui/snip.rkt
@@ -6,6 +6,7 @@
          plot/private/common/parameter-groups
          plot/private/common/parameter-group
          plot/private/common/draw-attribs
+         plot/private/common/color-map
          "worker-thread.rkt")
 
 (provide plot-snip%)

--- a/plot-gui-lib/plot/private/gui/snip2d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip2d.rkt
@@ -8,6 +8,7 @@
          plot/private/common/parameter-groups
          plot/private/common/parameter-group
          plot/private/common/draw-attribs
+         plot/private/common/color-map
          plot/private/plot2d/plot-area
          plot/private/plot2d/renderer
          plot/private/no-gui/plot2d-utils

--- a/plot-lib/plot/private/common/color-map.rkt
+++ b/plot-lib/plot/private/common/color-map.rkt
@@ -1,0 +1,286 @@
+#lang typed/racket/base
+(require racket/match
+         racket/math
+         "draw-attribs.rkt"
+         "type-doc.rkt"
+         "types.rkt"
+         "parameters.rkt")
+
+
+;;.................................... declare the predefined color maps ....
+
+;; These color maps correspond to the Matplotlib 3.0.3 qualitative color maps
+;; with the same names.  See
+;; https://matplotlib.org/examples/color/colormaps_reference.html
+
+(: color-map-pastel1 Color-Map)
+(define color-map-pastel1
+  #((251 180 174)
+    (179 205 227)
+    (204 235 197)
+    (222 203 228)
+    (254 217 166)
+    (255 255 204)
+    (229 216 189)
+    (253 218 236)
+    (242 242 242)))
+
+(: color-map-pastel2 Color-Map)
+(define color-map-pastel2
+  #((179 226 205)
+    (253 205 172)
+    (203 213 232)
+    (244 202 228)
+    (230 245 201)
+    (255 242 174)
+    (241 226 204)
+    (204 204 204)))
+
+(: color-map-paired Color-Map)
+(define color-map-paired
+  #((166 206 227)
+    (31 120 180)
+    (178 223 138)
+    (51 160 44)
+    (251 154 153)
+    (227 26 28)
+    (253 191 111)
+    (255 127 0)
+    (202 178 214)
+    (106 61 154)
+    (255 255 153)
+    (177 89 40)))
+
+(: color-map-accent Color-Map)
+(define color-map-accent
+  #((127 201 127)
+    (190 174 212)
+    (253 192 134)
+    (255 255 153)
+    (56 108 176)
+    (240 2 127)
+    (191 91 22)
+    (102 102 102)))
+
+(: color-map-dark2 Color-Map)
+(define color-map-dark2
+  #((27 158 119)
+    (217 95 2)
+    (117 112 179)
+    (231 41 138)
+    (102 166 30)
+    (230 171 2)
+    (166 118 29)
+    (102 102 102)))
+
+(: color-map-set1 Color-Map)
+(define color-map-set1
+  #((228 26 28)
+    (55 126 184)
+    (77 175 74)
+    (152 78 163)
+    (255 127 0)
+    (255 255 51)
+    (166 86 40)
+    (247 129 191)
+    (153 153 153)))
+
+(: color-map-set2 Color-Map)
+(define color-map-set2
+  #((102 194 165)
+    (252 141 98)
+    (141 160 203)
+    (231 138 195)
+    (166 216 84)
+    (255 217 47)
+    (229 196 148)
+    (179 179 179)))
+
+(: color-map-set3 Color-Map)
+(define color-map-set3
+  #((141 211 199)
+    (255 255 179)
+    (190 186 218)
+    (251 128 114)
+    (128 177 211)
+    (253 180 98)
+    (179 222 105)
+    (252 205 229)
+    (217 217 217)
+    (188 128 189)
+    (204 235 197)
+    (255 237 111)))
+
+(: color-map-tab10 Color-Map)
+(define color-map-tab10
+  #((31 119 180)
+    (255 127 14)
+    (44 160 44)
+    (214 39 40)
+    (148 103 189)
+    (140 86 75)
+    (227 119 194)
+    (127 127 127)
+    (188 189 34)
+    (23 190 207)))
+
+(: color-map-tab20 Color-Map)
+(define color-map-tab20
+  #((31 119 180)
+    (174 199 232)
+    (255 127 14)
+    (255 187 120)
+    (44 160 44)
+    (152 223 138)
+    (214 39 40)
+    (255 152 150)
+    (148 103 189)
+    (197 176 213)
+    (140 86 75)
+    (196 156 148)
+    (227 119 194)
+    (247 182 210)
+    (127 127 127)
+    (199 199 199)
+    (188 189 34)
+    (219 219 141)
+    (23 190 207)
+    (158 218 229)))
+
+(: color-map-tab20b Color-Map)
+(define color-map-tab20b
+  #((57 59 121)
+    (82 84 163)
+    (107 110 207)
+    (156 158 222)
+    (99 121 57)
+    (140 162 82)
+    (181 207 107)
+    (206 219 156)
+    (140 109 49)
+    (189 158 57)
+    (231 186 82)
+    (231 203 148)
+    (132 60 57)
+    (173 73 74)
+    (214 97 107)
+    (231 150 156)
+    (123 65 115)
+    (165 81 148)
+    (206 109 189)
+    (222 158 214)))
+
+(: color-map-tab20c Color-Map)
+(define color-map-tab20c
+  #((49 130 189)
+    (107 174 214)
+    (158 202 225)
+    (198 219 239)
+    (230 85 13)
+    (253 141 60)
+    (253 174 107)
+    (253 208 162)
+    (49 163 84)
+    (116 196 118)
+    (161 217 155)
+    (199 233 192)
+    (117 107 177)
+    (158 154 200)
+    (188 189 220)
+    (218 218 235)
+    (99 99 99)
+    (150 150 150)
+    (189 189 189)
+    (217 217 217)))
+
+;; New Tableau 10 color map from
+;; https://www.tableau.com/about/blog/2016/7/colors-upgrade-tableau-10-56782
+(: color-map-tab10n Color-Map)
+(define color-map-tab10n
+  #((78 121 165)
+    (241 143 59)
+    (224 88 91)
+    (119 183 178)
+    (90 161 85)
+    (237 201 88)
+    (175 122 160)
+    (254 158 168)
+    (156 117 97)
+    (186 176 172)))
+
+(define color-maps
+  (hash-copy ; hash copy will make our hash table mutable, allowing register-color-map to work
+   (hash
+    'pastel1 color-map-pastel1
+    'pastel2 color-map-pastel2
+    'paired color-map-paired
+    'dark2 color-map-dark2
+    'set1 color-map-set1
+    'set2 color-map-set2
+    'set3 color-map-set3
+    'tab10 color-map-tab10
+    'tab10n color-map-tab10n
+    'tab20 color-map-tab20
+    'tab20b color-map-tab20b
+    'tab20c color-map-tab20c)))
+
+
+
+;;.................................................. color map interface ....
+
+(: color-map-names (-> (Listof Symbol)))
+(define (color-map-names)
+  (hash-keys color-maps))
+
+(: color-map-size (-> Symbol Nonnegative-Integer))
+(define (color-map-size name)
+  (define cm (hash-ref color-maps name
+                       (lambda () (error (format "Unknown color map name: ~a" name)))))
+  (vector-length cm))
+
+(: register-color-map (-> Symbol Color-Map Any))
+(define (register-color-map name cm)
+  (hash-set! color-maps name cm))
+
+
+(:: ->color-map-pen-color (-> Integer (List Byte Byte Byte)))
+(define (->color-map-pen-color index)
+  (define cm
+    (cast 
+     (if (symbol? (plot-pen-color-map))
+         (hash-ref color-maps (plot-pen-color-map)
+                   (lambda () default-pen-colors))
+         default-pen-colors)
+     Color-Map))
+  (define i (modulo index (vector-length cm)))
+  (vector-ref cm i))
+
+(:: ->color-map-brush-color (-> Integer (List Byte Byte Byte)))
+(define (->color-map-brush-color index)
+  (define cm
+    (cast
+     (if (symbol? (plot-brush-color-map))
+         (hash-ref color-maps (plot-brush-color-map)
+                   (lambda () default-brush-colors))
+         default-brush-colors)
+     Color-Map))
+  (define i (modulo index (vector-length cm)))
+  (vector-ref cm i))
+
+(:: ->pen-color (-> Plot-Color (List Real Real Real)))
+(define (->pen-color c)
+  (cond [(exact-integer? c)  (->color-map-pen-color c)]
+        [else                (->color c)]))
+
+(:: ->brush-color (-> Plot-Color (List Real Real Real)))
+(define (->brush-color c)
+  (cond [(exact-integer? c)  (->color-map-brush-color c)]
+        [else                (->color c)]))
+
+(provide
+ color-map-names
+ color-map-size
+ register-color-map
+ ->pen-color
+ ->brush-color)
+

--- a/plot-lib/plot/private/common/draw-attribs.rkt
+++ b/plot-lib/plot/private/common/draw-attribs.rkt
@@ -154,8 +154,8 @@
   (define r (assert (+ 127 (* 128 (expt (max 0 (- 1 (integer->gray-value i))) 3/4))) real?))
   (list r r r))
 
-(: pen-colors (Vectorof (List Byte Byte Byte)))
-(define pen-colors
+(: default-pen-colors (Vectorof (List Byte Byte Byte)))
+(define default-pen-colors
   (for/vector ([color  (in-list (append (list (integer->gray-pen-color 0))
                                         (build-list 120 integer->pen-color)
                                         (build-list 7 (λ ([n : Index])
@@ -166,8 +166,8 @@
           (real->color-byte g)
           (real->color-byte b))))
 
-(: brush-colors (Vectorof (List Byte Byte Byte)))
-(define brush-colors
+(: default-brush-colors (Vectorof (List Byte Byte Byte)))
+(define default-brush-colors
   (for/vector ([color  (in-list (append (list (integer->gray-brush-color 0))
                                         (build-list 120 integer->brush-color)
                                         (build-list 7 (λ ([n : Index])
@@ -177,16 +177,6 @@
     (list (real->color-byte r)
           (real->color-byte g)
           (real->color-byte b))))
-
-(:: ->pen-color (-> Plot-Color (List Real Real Real)))
-(define (->pen-color c)
-  (cond [(exact-integer? c)  (vector-ref pen-colors (modulo c 128))]
-        [else                (->color c)]))
-
-(:: ->brush-color (-> Plot-Color (List Real Real Real)))
-(define (->brush-color c)
-  (cond [(exact-integer? c)  (vector-ref brush-colors (modulo c 128))]
-        [else                (->color c)]))
 
 (:: ->pen-style (-> Plot-Pen-Style Plot-Pen-Style-Sym))
 (define (->pen-style s)
@@ -235,3 +225,31 @@
         [gs  (linear-seq* gs num #:start? start? #:end? end?)]
         [bs  (linear-seq* bs num #:start? start? #:end? end?)])
     (map (λ ([r : Real] [g : Real] [b : Real]) (list r g b)) rs gs bs)))
+
+(:: default-contour-colors (-> (Listof Real) (Listof Plot-Color)))
+(define (default-contour-colors zs)
+  (color-seq* (list (vector-ref default-pen-colors 5)
+                    (vector-ref default-pen-colors 0)
+                    (vector-ref default-pen-colors 1))
+              (length zs)))
+
+(:: default-contour-fill-colors (-> (Listof ivl) (Listof Plot-Color)))
+(define (default-contour-fill-colors z-ivls)
+  (color-seq* (list (vector-ref default-brush-colors 5)
+                    (vector-ref default-brush-colors 0)
+                    (vector-ref default-brush-colors 1))
+              (length z-ivls)))
+
+(:: default-isosurface-colors (-> (Listof Real) (Listof Plot-Color)))
+(define (default-isosurface-colors zs)
+  (color-seq* (list (vector-ref default-brush-colors 5)
+                    (vector-ref default-brush-colors 0)
+                    (vector-ref default-brush-colors 1))
+              (length zs)))
+
+(:: default-isosurface-line-colors (-> (Listof Real) (Listof Plot-Color)))
+(define (default-isosurface-line-colors zs)
+  (color-seq* (list (vector-ref default-pen-colors 5)
+                    (vector-ref default-pen-colors 0)
+                    (vector-ref default-pen-colors 1))
+              (length zs)))

--- a/plot-lib/plot/private/common/parameter-groups.rkt
+++ b/plot-lib/plot/private/common/parameter-groups.rkt
@@ -35,7 +35,9 @@
      plot-legend-anchor plot-legend-box-alpha
      plot-axes? plot-tick-labels
      plot-decorations?
-     plot-animating?))
+     plot-animating?
+     plot-pen-color-map
+     plot-brush-color-map))
   
   (define-parameter-group plot3d-appearance
     (plot3d-samples
@@ -95,7 +97,9 @@
       (List Boolean Boolean Boolean Boolean Boolean Boolean)
       (List Boolean Anchor Real (U Boolean 'auto) Anchor Real Boolean Anchor Real (U Boolean 'auto) Anchor Real)
       Boolean
-      Boolean)
+      Boolean
+      (U Symbol #f)
+      (U Symbol #f))
      (List Positive-Integer Real Real Nonnegative-Real Boolean Boolean)
      (List
       (U False String)

--- a/plot-lib/plot/private/common/parameters.rkt
+++ b/plot-lib/plot/private/common/parameters.rkt
@@ -62,8 +62,8 @@
 
 (defparam2 plot-width Integer Positive-Integer 400 (integer>=1 'plot-width))
 (defparam2 plot-height Integer Positive-Integer 400 (integer>=1 'plot-height))
-(defparam plot-foreground color Plot-Color 0)
-(defparam plot-background color Plot-Color 0)
+(defparam plot-foreground color Plot-Color "black")
+(defparam plot-background color Plot-Color "white")
 (defparam2 plot-foreground-alpha alpha Real Nonnegative-Real 1 (unit-ivl 'plot-foreground-alpha))
 (defparam2 plot-background-alpha alpha Real Nonnegative-Real 1 (unit-ivl 'plot-background-alpha))
 (defparam2 plot-line-width width Real Nonnegative-Real 1 (nonnegative-rational 'plot-line-width))
@@ -102,6 +102,9 @@
 (defparam plot-y-far-tick-label-anchor anchor Anchor 'left)
 
 (defparam plot-decorations? Boolean #t)
+
+(defparam plot-pen-color-map (U Symbol #f) #f)
+(defparam plot-brush-color-map (U Symbol #f) #f)
 
 (:: pen-gap (-> Real))
 (define (pen-gap)
@@ -224,16 +227,6 @@
 
 ;; Contours
 
-(:: default-contour-colors (-> (Listof Real) (Listof Plot-Color)))
-(define (default-contour-colors zs)
-  (color-seq* (list (->pen-color 5) (->pen-color 0) (->pen-color 1))
-              (length zs)))
-
-(:: default-contour-fill-colors (-> (Listof ivl) (Listof Plot-Color)))
-(define (default-contour-fill-colors z-ivls)
-  (color-seq* (list (->brush-color 5) (->brush-color 0) (->brush-color 1))
-              (length z-ivls)))
-
 (defparam2 contour-samples Integer Positive-Integer 51 (integer>=2 'contour-samples))
 (defparam contour-levels Contour-Levels 'auto)
 (defparam contour-colors (Plot-Colors (Listof Real)) default-contour-colors)
@@ -312,16 +305,6 @@
 (defparam contour-interval-line-styles (Plot-Pen-Styles (Listof ivl)) '(solid))
 
 ;; Isosurfaces
-
-(:: default-isosurface-colors (-> (Listof Real) (Listof Plot-Color)))
-(define (default-isosurface-colors zs)
-  (color-seq* (list (->brush-color 5) (->brush-color 0) (->brush-color 1))
-              (length zs)))
-
-(:: default-isosurface-line-colors (-> (Listof Real) (Listof Plot-Color)))
-(define (default-isosurface-line-colors zs)
-  (color-seq* (list (->pen-color 5) (->pen-color 0) (->pen-color 1))
-              (length zs)))
 
 (defparam isosurface-levels Contour-Levels 'auto)
 (defparam isosurface-colors (Plot-Colors (Listof Real)) default-isosurface-colors)

--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -10,6 +10,7 @@
          typed/racket/class
          racket/match racket/math racket/bool racket/list racket/vector
          "draw-attribs.rkt"
+         "color-map.rkt"
          "draw.rkt"
          "math.rkt"
          "sample.rkt"

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -27,6 +27,8 @@
 (deftype Plot-Color
   (U Integer Color))
 
+(deftype Color-Map (Vectorof (List Byte Byte Byte))) 
+
 (deftype Plot-Pen-Style-Sym
   (U 'transparent 'solid    'dot 'long-dash
      'short-dash  'dot-dash))

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -8,6 +8,7 @@
          "../common/plot-device.rkt"
          "../common/ticks.rkt"
          "../common/draw-attribs.rkt"
+         "../common/color-map.rkt"
          "../common/draw.rkt"
          "../common/axis-transform.rkt"
          "../common/parameters.rkt"

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -47,7 +47,8 @@
  stretch-transform
  collapse-transform)
 
-(require "common/parameters.rkt")
+(require "common/parameters.rkt"
+         "common/draw-attribs.rkt")
 
 (provide
  plot-deprecation-warnings?
@@ -86,6 +87,8 @@
  plot-legend-box-alpha
  plot-decorations?
  plot-animating?
+ plot-pen-color-map
+ plot-brush-color-map
  plot3d-samples
  plot3d-angle
  plot3d-altitude

--- a/plot-lib/plot/utils.rkt
+++ b/plot-lib/plot/utils.rkt
@@ -142,16 +142,25 @@
  parse-format-string
  apply-formatter)
 
-(require "private/common/draw-attribs.rkt")
+(require (only-in "private/common/draw-attribs.rkt"
+                  ->color
+                  ->pen-style
+                  ->brush-style
+                  color-seq
+                  color-seq*)
+         "private/common/color-map.rkt")
 
 (provide
  ->color
- ->pen-color
- ->brush-color
  ->pen-style
  ->brush-style
  color-seq
- color-seq*)
+ color-seq*
+ ->pen-color
+ ->brush-color
+ color-map-names
+ color-map-size
+ register-color-map)
 
 (require "private/common/sample.rkt")
 


### PR DESCRIPTION
Plot renderers have a `#:color` argument which specifies the color to use for drawing, this can be a `color%` object, a RGB triplet, or an integer representing an index into a color palette.  This commit introduces a mechanism to select which color palette (called a color map) to use when integers are used for the `#:color` argument of the renderers.

```racket
(require plot)
(parameterize ([plot-pen-color-map 'set1]
               [line-width 3])
    (plot (list (function sin -5 5 #:color 0)
                (function cos -5 5 #:color 1))))
```

![sample-plot](https://user-images.githubusercontent.com/11592690/54753279-99d1c400-4c1b-11e9-9b66-f4e94931b549.png)


The following new API functions are introduced and updated:

* `plot-pen-color-map` and `plot-brush-color-map` are new parameters which specify the name of a color map to use for the `#:color` argument of renderer functions.

* the `->pen-color` and `->brush-color` functions have been updated to use the current color map for lookups. These functions are used internally to convert integers to a RGB triplet, but they are also available in `plot/utils`.

* The `plot-foreground` and `plot-background` parameters have been changed to "black" and "white" respectively, this was done to avoid drawing the axes and text in the first color of the pen color map and the background in the first color of the brush color map.

* `color-map-names` is a new function which returns the list of color map names as a list of symbols.

* `color-map-size` is a function which returns the number of colors in a color map.  Note that `->pen-color` and `->brush-color` will cycle the colors in the color map, so any integer argument is valid for these functions.

* `register-color-map` allows registering new color maps.

The last three functions are available in the `plot/utils` module, but not `plot`.  This is consistent with the availability of `->pen-color`.

The following color map names are also added, they are based on the matplotlib and ggplot2 color maps and use the same names: dark2, paired, pastel1, pastel2, set1, set2, set3, tab10, tab10n, tab20, tab20b and tab20c.

![color-maps](https://user-images.githubusercontent.com/11592690/54753344-c554ae80-4c1b-11e9-9d5f-bc462533b899.png)

The default plot colors are not changed with this commit, if the user does not specify a color map using `plot-pen-color-map` or `plot-brush-color-map`, the plot will use the same colors as before.

Some functions have been moved to different files, this was done to avoid circular dependencies.

# Some other notes

* There is a `racket-lang` discution about this feature [here](https://groups.google.com/forum/#!topic/racket-users/lGPYVc7s3ww)

* This pull request does not cover using contour colors for various 3d plots or changing the defaults for the color maps, these can be addressed in subsequent pull requests

* The color maps use list of three bytes as color definitions, this is consistent with what `->pen-color` returns, and has not changed -- it is not very convenient for using this feature outside the plot package, but it is consistent with how the plot package works.

* Once everyone is happy with the defined API, I will update the Scribble documentation and push the changes to this pull request.

The color map picture was generated using the code below, which also illustrates how to use `color-map-names` and `color-map-size`:

```racket
#lang racket
(require plot plot/utils pict racket/draw)

(define (pp-color-maps (width 400) (height 30))
  (define cm-names (sort (color-map-names)
                         (lambda (a b)
                           (string<=? (symbol->string a) (symbol->string b)))))
  (define cm-labels
    (for/list ([cm cm-names])
      (text (symbol->string cm) null 16)))
  (define cm-picts
    (for/list ([cm cm-names])
      (parameterize ([plot-pen-color-map cm])
        (define w (/ width (color-map-size cm)))
        (apply
         hc-append 0
         (for/list ([c (in-range (color-map-size cm))])
           (match-define (list r g b) (->pen-color c))
           (define color (make-object color% r g b))
           (filled-rectangle w height #:draw-border? #f #:color color))))))
  (define picts
    (let loop ([result '()]
               [labels cm-labels]
               [picts cm-picts])
      (if (null? labels)
          (reverse result)
          (loop (cons (car picts) (cons (car labels) result))
                (cdr labels)
                (cdr picts)))))
  (table 2 picts lc-superimpose cc-superimpose 15 3))
```
