### PR TITLE
use plot/no-gui instead of plot while rendering the scribble documentation

### DIFF
--- a/plot-doc/plot/scribblings/common.rkt
+++ b/plot-doc/plot/scribblings/common.rkt
@@ -43,7 +43,7 @@
 (define (close-plot-eval)
   (close-eval plot-eval))
 
-(require plot plot/utils pict racket/match racket/class racket/draw)
+(require plot/no-gui plot/utils pict racket/match racket/class racket/draw)
 (define (pretty-print-color-maps (width 400) (height 30))
   (define cm-names
     (sort (color-map-names)


### PR DESCRIPTION
Requiring and initializing the GUI while building the documentation fails the
build.  The code to generate the color map picture only requires plot/no-gui
functions anyway.

As per discussion at https://github.com/racket/plot/commit/0e30a09f7499fb8349759fbf714b070d9255e3b4#commitcomment-33013748