### PR TITLE
match use of latitude and longitude, and their domain

### DIFF
--- a/plot-doc/plot/scribblings/renderer3d.scrbl
+++ b/plot-doc/plot/scribblings/renderer3d.scrbl
@@ -161,20 +161,21 @@ Returns a renderer that plots a two-input, one-output function. For example,
           [#:alpha alpha (real-in 0 1) (surface-alpha)]
           [#:label label (or/c string? #f) #f]
           ) renderer3d?]{
-Returns a renderer that plots a function from latitude and longitude to radius.
+Returns a renderer that plots a function from longitude and latitude to radius.
+@racket[(f θ ϕ)] → @racket[r]
 
-Currently, latitudes range from @(racket 0) to @(racket (* 2 pi)), and longitudes from @(racket (* -1/2 pi)) to @(racket (* 1/2 pi)).
+Currently, longitudes(θ) range from @(racket 0) to @(racket (* 2 pi)), and latitudes(ϕ) from @(racket (* -1/2 pi)) to @(racket (* 1/2 pi)).
 These intervals may become optional arguments to @racket[polar3d] in the future.
 
 A sphere is the graph of a polar function of constant radius:
-@interaction[#:eval plot-eval (plot3d (polar3d (λ (θ ρ) 1)) #:altitude 25)]
+@interaction[#:eval plot-eval (plot3d (polar3d (λ (θ ϕ) 1)) #:altitude 25)]
 
 Combining polar function renderers allows faking latitudes or longitudes in larger ranges, to get, for example, a seashell plot:
 @interaction[#:eval plot-eval
                     (parameterize ([plot-decorations?  #f]
                                    [plot3d-samples     75])
-                      (define (f1 θ ρ) (+ 1 (/ θ 2 pi) (* 1/8 (sin (* 8 ρ)))))
-                      (define (f2 θ ρ) (+ 0 (/ θ 2 pi) (* 1/8 (sin (* 8 ρ)))))
+                      (define (f1 θ ϕ) (+ 1 (/ θ 2 pi) (* 1/8 (sin (* 8 ϕ)))))
+                      (define (f2 θ ϕ) (+ 0 (/ θ 2 pi) (* 1/8 (sin (* 8 ϕ)))))
                       
                       (plot3d (list (polar3d f1 #:color "navajowhite"
                                              #:line-style 'transparent #:alpha 2/3)

--- a/plot-lib/plot/private/plot3d/isosurface.rkt
+++ b/plot-lib/plot/private/plot3d/isosurface.rkt
@@ -297,8 +297,8 @@
      (define vs
        (for*/list : (Listof (Vectorof Real))
          ([θ  (in-list (linear-seq 0.0 2pi (* 4 samples)))]
-          [ρ  (in-list (linear-seq (* -1/2 pi) (* 1/2 pi) (* 2 samples)))])
-         (3d-polar->3d-cartesian θ ρ (f θ ρ))))
+          [ϕ  (in-list (linear-seq (* -1/2 pi) (* 1/2 pi) (* 2 samples)))])
+         (3d-polar->3d-cartesian θ ϕ (f θ ϕ))))
      (define rvs (filter vrational? vs))
      (cond [(empty? rvs)  (renderer3d #f #f #f #f)]
            [else


### PR DESCRIPTION
This addresses issue #48 
to add my 2cts to the discussion:
latitude and longitude are used for navigation on a/our globe
latitude is from pole to pole: ie from 90°South to 90°North,
Longitude is from 180°West to 180°East
so latitude conforms with the (- (/ pi 2)) to (/ pi 2) and longitude goes from (- pi) to pi (or alternatively from 0 to (* 2 pi))

For polar coordinates you have one angle going trough 360° and one going trough 180°
in the implementation the first angle (theta) is going trough 360° and the second trough 180°
This is how it is usually done, with the understanding that the 360° usually goes around the equator (here hardwired to the xy-plane) and the second angle from pole to pole

The mix up in my opinion is because in math you usually specify first the 360° angle, then the 180° where in navigation you first say latitude, then longitude.

I also changed the symbols because rho is used for a radius (or a projected radius in azimuth projection) whereas theta and phi are more mainstream for the angles.