### PR TITLE
Setup CI for the plot package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
       - run: raco pkg config catalogs >> catalogs.txt
       - run: raco pkg config --set catalogs `cat catalogs.txt`
       - run: raco pkg config catalogs
-      # - run: sudo raco pkg install --batch --auto plot
+      - run: sudo raco pkg install --batch --auto plot
       # - run: raco test --drdr plot-test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           variant: ${{ matrix.racket-variant }}
           version: ${{ matrix.racket-version }}
       - run: racket -l- pkg/dirs-catalog --link catalog .
-      - run: CPATH=`pwd` echo "file://$CPATH/catalog" > catalogs.txt
+      - run: echo "file://`pwd`/catalog" > catalogs.txt
       - run: raco pkg config catalogs >> catalogs.txt
       - run: raco pkg config --set catalogs `cat catalogs.txt`
       - run: raco pkg config catalogs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: ["7.7"]
-        racket-variant: ["regular"]
+        racket-version: ["7.7", "current"]
+        racket-variant: ["regular", "CS"]
     steps:
       - uses: actions/checkout@master
-      - uses: Bogdanp/setup-racket@v0.3
+      - uses: Bogdanp/setup-racket@v0.8
         with:
           architecture: x64
           distribution: minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,6 @@ jobs:
       - run: CPATH=`pwd` echo "file://$CPATH/catalog" > catalogs.txt
       - run: raco pkg config catalogs >> catalogs.txt
       - run: raco pkg config --set catalogs `cat catalogs.txt`
-      - run: sudo raco pkg install --batch --auto plot/
-      - run: raco test --drdr plot-test/
+      - run: raco pkg config catalogs
+      # - run: sudo raco pkg install --batch --auto plot
+      # - run: raco test --drdr plot-test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        racket-version: ["7.6", "7.7", "current"]
-        racket-variant: ["regular", "CS"]
+        racket-version: ["7.7"]
+        racket-variant: ["regular"]
     steps:
       - uses: actions/checkout@master
       - uses: Bogdanp/setup-racket@v0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
       - uses: Bogdanp/setup-racket@v0.3
         with:
           architecture: x64
-          distribution: full
+          distribution: minimal
           variant: ${{ matrix.racket-variant }}
           version: ${{ matrix.racket-version }}
-      - run: sudo raco pkg update --name plot --link --batch --auto plot/
+      - run: racket -l- pkg/dirs-catalog --link catalog .
+      - run: CPATH=`pwd` echo "file://$CPATH/catalog" > catalogs.txt
+      - run: raco pkg config catalogs >> catalogs.txt
+      - run: raco pkg config --set catalogs `cat catalogs.txt`
       - run: sudo raco pkg install --batch --auto plot/
       - run: raco test --drdr plot-test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+name: CI
+jobs:
+  build:
+    name: "Build on Racket '${{ matrix.racket-version }}' (${{ matrix.racket-variant }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        racket-version: ["7.6", "7.7", "current"]
+        racket-variant: ["regular", "CS"]
+    steps:
+      - uses: actions/checkout@master
+      - uses: Bogdanp/setup-racket@v0.3
+        with:
+          architecture: x64
+          distribution: full
+          variant: ${{ matrix.racket-variant }}
+          version: ${{ matrix.racket-version }}
+      - run: sudo raco pkg update --name plot --link --batch --auto plot/
+      - run: sudo raco pkg install --batch --auto plot/
+      - run: raco test --drdr plot-test/


### PR DESCRIPTION
This sets up a CI build for the plot package, scheduled to run for pushes and pull requests.  Currently it only runs for Racket version 7.7 and it does not run the tests.  Tests need are currently run manually and their output visually inspected.

It is inspired by the web-server CI build, but uses a different strategy for the build:

* minimal racket is installed
* a package catalog is setup for the packages in the plot repository
* this package catalog is added to the default racket catalogs
* the plot package is installed -- this will fetch packages form the local file system and build them, and will fetch all dependencies from the main racket catalog.

NOTE: there are several commits in this branch, as I was experimenting with different approaches, but I will squash the commits when merged to the master branch, so only one commit shows up.