### PR TITLE
[legend pt1] legend outside plot area

### DIFF
--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -112,11 +112,14 @@
                 legend-entries-hash (plot-animating?)
                 (flatten-legend-entries
                  (for/list : (Listof (Treeof legend-entry)) ([rend  (in-list renderer-list)])
-                   (match-define (renderer3d rend-bounds-rect _bf _tf render-proc) rend)
+                   (match-define (renderer3d rend-bounds-rect _bf _tf label-proc render-proc) rend)
                    (send area start-renderer (if rend-bounds-rect
                                                  (rect-inexact->exact rend-bounds-rect)
                                                  (unknown-rect 3)))
-                   (if render-proc (render-proc area) empty))))
+                   (when render-proc (render-proc area))
+                   (if label-proc
+                       (label-proc (send area get-bounds-rect))
+                       empty))))
 
                (hash-set! render-tasks-hash (plot-animating?) (send area get-render-tasks))]
               [else

--- a/plot-lib/plot/private/no-gui/plot2d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d-utils.rkt
@@ -20,7 +20,7 @@
   (cond [(list? renderer-tree)  (append* (map get-renderer-list renderer-tree))]
         [(nonrenderer? renderer-tree)
          (match-define (nonrenderer bounds-rect bounds-fun ticks-fun) renderer-tree)
-         (list (renderer2d bounds-rect bounds-fun ticks-fun #f))]
+         (list (renderer2d bounds-rect bounds-fun ticks-fun #f #f))]
         [(renderer2d? renderer-tree)
          (list renderer-tree)]
         [else
@@ -71,11 +71,16 @@
   (define legend-entries
     (flatten-legend-entries
      (for/list : (Listof (Treeof legend-entry)) ([rend  (in-list renderer-list)])
-       (match-define (renderer2d rend-bounds-rect _bf _tf render-proc) rend)
+       (match-define (renderer2d rend-bounds-rect _bf _tf label-proc render-proc) rend)
        (send area start-renderer (if rend-bounds-rect
                                      (rect-inexact->exact rend-bounds-rect)
                                      (unknown-rect 2)))
-       (if render-proc (render-proc area) empty))))
+       (when render-proc (render-proc area))
+       (cond
+         [(and render-proc label-proc)
+          (define rect (send area get-bounds-rect))
+          (label-proc rect)]
+         [else empty]))))
   
   (send area end-renderers)
   

--- a/plot-lib/plot/private/no-gui/plot3d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d-utils.rkt
@@ -20,7 +20,7 @@
   (cond [(list? renderer-tree)  (append* (map get-renderer-list renderer-tree))]
         [(nonrenderer? renderer-tree)
          (match-define (nonrenderer bounds-rect bounds-fun ticks-fun) renderer-tree)
-         (list (renderer3d bounds-rect bounds-fun ticks-fun #f))]
+         (list (renderer3d bounds-rect bounds-fun ticks-fun #f #f))]
         [(renderer3d? renderer-tree)
          (list renderer-tree)]
         [else
@@ -81,11 +81,14 @@
   (define legend-entries
     (flatten-legend-entries
      (for/list : (Listof (Treeof legend-entry)) ([rend  (in-list renderer-list)])
-       (match-define (renderer3d rend-bounds-rect _bf _tf render-proc) rend)
+       (match-define (renderer3d rend-bounds-rect _bf _tf label-proc render-proc) rend)
        (send area start-renderer (if rend-bounds-rect
                                      (rect-inexact->exact rend-bounds-rect)
                                      (unknown-rect 3)))
-       (if render-proc (render-proc area) empty))))
+       (when render-proc (render-proc area))
+       (if label-proc
+           (label-proc (send area get-bounds-rect))
+           empty))))
   
   (send area end-renderers)
   

--- a/plot-lib/plot/private/plot2d/color-field.rkt
+++ b/plot-lib/plot/private/plot2d/color-field.rkt
@@ -29,25 +29,22 @@
 (define ((color-field-render-fun f samples alpha) area)
   (match-define (vector (ivl x-min x-max) (ivl y-min y-max)) (send area get-bounds-rect))
   
-  (cond
-    [(and x-min x-max y-min y-max)
-     (define xs (linear-seq x-min x-max (+ samples 1) #:start? #t #:end? #t))
-     (define ys (linear-seq y-min y-max (+ samples 1) #:start? #t #:end? #t))
+  (when (and x-min x-max y-min y-max)
+    (define xs (linear-seq x-min x-max (+ samples 1) #:start? #t #:end? #t))
+    (define ys (linear-seq y-min y-max (+ samples 1) #:start? #t #:end? #t))
 
-     (send area put-alpha alpha)
-     (send area put-pen 'black 0 'transparent)
-     (for ([x- (in-list xs)]
-           [x+ (in-list (cdr xs))])
-       (define x (/ (+ x- x+) 2))
-       (for ([y- (in-list ys)]
-             [y+ (in-list (cdr ys))])
-         (define y (/ (+ y- y+) 2))
-         (define c (f x y))
-         (send area put-brush c 'solid)
-         (send area put-rect (vector (ivl x- x+)
-                                     (ivl y- y+)))))
-     empty]
-    [else  empty]))
+    (send area put-alpha alpha)
+    (send area put-pen 'black 0 'transparent)
+    (for ([x- (in-list xs)]
+          [x+ (in-list (cdr xs))])
+      (define x (/ (+ x- x+) 2))
+      (for ([y- (in-list ys)]
+            [y+ (in-list (cdr ys))])
+        (define y (/ (+ y- y+) 2))
+        (define c (f x y))
+        (send area put-brush c 'solid)
+        (send area put-rect (vector (ivl x- x+)
+                                    (ivl y- y+)))))))
 
 (:: color-field
     (->* [(U (-> Real Real Plot-Color)
@@ -70,7 +67,7 @@
     [(or (> alpha 1) (not (rational? alpha)))  (fail/kw "real in [0,1]" '#:alpha alpha)]
     [else
      (let ([f ((inst fix-a-field-fun Plot-Color) 'color-field f)])
-       (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun
+       (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun #f
                    (color-field-render-fun
                     f samples alpha)))]))
 

--- a/plot-lib/plot/private/plot2d/contour.rkt
+++ b/plot-lib/plot/private/plot2d/contour.rkt
@@ -16,12 +16,9 @@
 (: isoline-render-proc (-> 2D-Sampler Real Positive-Integer
                            Plot-Color Nonnegative-Real Plot-Pen-Style
                            Nonnegative-Real
-                           (U String pict #f)
                            2D-Render-Proc))
-(define ((isoline-render-proc g z samples color width style alpha label) area)
+(define ((isoline-render-proc g z samples color width style alpha) area)
   (match-define (vector x-ivl y-ivl) (send area get-bounds-rect))
-  (match-define (ivl x-min x-max) x-ivl)
-  (match-define (ivl y-min y-max) y-ivl)
   (define num (animated-samples samples))
   (define sample (g (vector x-ivl y-ivl) (vector num num)))
   (match-define (2d-sample xs ys zss z-min z-max) sample)
@@ -34,9 +31,7 @@
      (for ([line  (in-list (heights->lines xa xb ya yb z z1 z2 z3 z4))])
        (match-define (list v1 v2) (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) line))
        (send area put-line v1 v2))))
-  
-  (cond [label  (line-legend-entry label color width style)]
-        [else   empty]))
+  (void))
 
 (:: isoline
     (->* [(-> Real Real Real) Real]
@@ -72,54 +67,77 @@
      (define y-ivl (ivl y-min y-max))
      (define g (2d-function->sampler f (vector x-ivl y-ivl)))
      (renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
-                 (isoline-render-proc g z samples color width style alpha label))]))
+                 (and label (λ (_) (line-legend-entry label color width style)))
+                 (isoline-render-proc g z samples color width style alpha))]))
 
 ;; ===================================================================================================
 ;; Contour lines
 
-(: contours-render-proc (-> 2D-Sampler Contour-Levels Positive-Integer
-                            (Plot-Colors (Listof Real))
-                            (Pen-Widths (Listof Real))
-                            (Plot-Pen-Styles (Listof Real))
-                            (Alphas (Listof Real))
-                            (U String pict #f)
-                            2D-Render-Proc))
-(define ((contours-render-proc g levels samples colors widths styles alphas label) area)
-  (let/ec return : (Treeof legend-entry)
-    (match-define (vector x-ivl y-ivl) (send area get-bounds-rect))
-    (match-define (ivl x-min x-max) x-ivl)
-    (match-define (ivl y-min y-max) y-ivl)
-    (define num (animated-samples samples))
-    (define sample (g (vector x-ivl y-ivl) (vector num num)))
-    (match-define (2d-sample xs ys zss z-min z-max) sample)
-    
-    (unless (and z-min z-max) (return empty))
-    
-    (match-define (list (tick #{zs : (Listof Real)}
-                              #{_ : (Listof Boolean)}
-                              #{labels : (Listof String)})
-                        ...)
-      (contour-ticks (plot-z-ticks) (assert z-min values) (assert z-max values) levels #f))
-    
-    (let* ([colors  (generate-list colors zs)]
-           [widths  (generate-list widths zs)]
-           [styles  (generate-list styles zs)]
-           [alphas  (generate-list alphas zs)])
-      (for ([z      (in-list zs)]
-            [color  (in-cycle* colors)]
-            [width : Nonnegative-Real  (in-cycle* widths)]
-            [style  (in-cycle* styles)]
-            [alpha : Nonnegative-Real  (in-cycle* alphas)])
-        (send area put-alpha alpha)
-        (send area put-pen color width style)
-        (for-2d-sample
-         (xa xb ya yb z1 z2 z3 z4) sample
-         (for ([line  (in-list (heights->lines xa xb ya yb z z1 z2 z3 z4))])
-           (match-define (list v1 v2) (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) line))
-           (send area put-line v1 v2)))))
-    
-    (cond [(and label (not (empty? zs)))  (line-legend-entries label zs labels colors widths styles)]
-          [else  empty])))
+(: make-contour-labels-and-renderer (-> 2D-Sampler Contour-Levels Positive-Integer
+                                (Plot-Colors (Listof Real))
+                                (Pen-Widths (Listof Real))
+                                (Plot-Pen-Styles (Listof Real))
+                                (Alphas (Listof Real))
+                                (U String pict #f)
+                                (List (U #f (-> Rect (Treeof legend-entry)))
+                                      2D-Render-Proc)))
+(define (make-contour-labels-and-renderer g levels samples colors widths styles alphas label)
+  (define last-rect   : (U #f Rect)     #f)
+  (define last-sample : 2d-sample       (2d-sample '() '() #() #f #f))
+  (define last-zs     : (Listof Real)   empty)
+  (define last-labels : (Listof String) empty)
+
+  (define (calculate-zs/labels [rect : Rect]) : (List 2d-sample (Listof Real) (Listof String))
+    (cond
+      [(equal? rect last-rect) (list last-sample last-zs last-labels)]
+      [else
+       (match-define (vector x-ivl y-ivl) rect)
+       (define num (animated-samples samples))
+       (define sample (g (vector x-ivl y-ivl) (vector num num)))
+       (match-define (2d-sample xs ys zss z-min z-max) sample)
+       (set! last-rect rect)
+       (set! last-sample sample)
+       (cond
+         [(and z-min z-max)
+          (match-define (list (tick #{zs : (Listof Real)}
+                                    #{_ : (Listof Boolean)}
+                                    #{labels : (Listof String)})
+                              ...)
+            (contour-ticks (plot-z-ticks) (assert z-min values) (assert z-max values) levels #f))
+          (set! last-zs zs)
+          (set! last-labels labels)
+          (list sample zs labels)]
+         [else
+          (set! last-zs     empty)
+          (set! last-labels empty)
+          (list sample empty empty)])]))
+
+  (list
+   (and label (λ ([rect : Rect])
+                (match-define (list _ zs labels) (calculate-zs/labels rect))
+                (if (empty? zs)
+                    '()
+                    (line-legend-entries label zs labels colors widths styles))))
+   (λ (area)
+     (match-define (list sample zs _)
+       (calculate-zs/labels (send area get-bounds-rect)))
+     (unless (empty? zs)
+       (let* ([colors  (generate-list colors zs)]
+              [widths  (generate-list widths zs)]
+              [styles  (generate-list styles zs)]
+              [alphas  (generate-list alphas zs)])
+         (for ([z      (in-list zs)]
+               [color  (in-cycle* colors)]
+               [width : Nonnegative-Real  (in-cycle* widths)]
+               [style  (in-cycle* styles)]
+               [alpha : Nonnegative-Real  (in-cycle* alphas)])
+           (send area put-alpha alpha)
+           (send area put-pen color width style)
+           (for-2d-sample
+            (xa xb ya yb z1 z2 z3 z4) sample
+            (for ([line  (in-list (heights->lines xa xb ya yb z z1 z2 z3 z4))])
+              (match-define (list v1 v2) (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) line))
+              (send area put-line v1 v2)))))))))
 
 (:: contours
     (->* [(-> Real Real Real)]
@@ -153,81 +171,120 @@
      (define x-ivl (ivl x-min x-max))
      (define y-ivl (ivl y-min y-max))
      (define g (2d-function->sampler f (vector x-ivl y-ivl)))
-     (renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
-                 (contours-render-proc g levels samples colors widths styles alphas label))]))
+     (apply renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
+            (make-contour-labels-and-renderer
+             g levels samples colors widths styles alphas label))]))
 
 ;; ===================================================================================================
 ;; Contour intervals
 
-(: contour-intervals-render-proc
+(: make-contour-intervals-labels-and-renderer
    (-> 2D-Sampler Contour-Levels Positive-Integer
        (Plot-Colors (Listof ivl)) (Plot-Brush-Styles (Listof ivl))
        (Plot-Colors (Listof Real)) (Pen-Widths (Listof Real)) (Plot-Pen-Styles (Listof Real))
        (Alphas (Listof ivl))
        (U String pict #f)
-       2D-Render-Proc))
-(define ((contour-intervals-render-proc
-          g levels samples colors styles contour-colors contour-widths contour-styles alphas label)
-         area)
-  (let/ec return : (Treeof legend-entry)
-    (match-define (vector x-ivl y-ivl) (send area get-bounds-rect))
-    (match-define (ivl x-min x-max) x-ivl)
-    (match-define (ivl y-min y-max) y-ivl)
-    (define num (animated-samples samples))
-    (define sample (g (vector x-ivl y-ivl) (vector num num)))
-    (match-define (2d-sample xs ys zss z-min z-max) sample)
-    
-    (unless (and z-min z-max) (return empty))
-    
-    (match-define (list (tick #{zs : (Listof Real)}
-                              #{_ : (Listof Boolean)}
-                              #{labels : (Listof String)})
-                        ...)
-      (contour-ticks (plot-z-ticks) (assert z-min values) (assert z-max values) levels #t))
-    
-    (define-values (z-ivls ivl-labels)
-      (for/lists ([z-ivls : (Listof ivl)]
-                  [ivl-labels : (Listof String)]
-                  ) ([za  (in-list zs)]
-                     [zb  (in-list (rest zs))]
-                     [la  (in-list labels)]
-                     [lb  (in-list (rest labels))])
-        (values (ivl za zb) (format "[~a,~a]" la lb))))
-    
-    (send area put-pen 0 1 'transparent)
-    (let* ([colors  (map ->brush-color (generate-list colors z-ivls))]
-           [styles  (map ->brush-style (generate-list styles z-ivls))]
-           [alphas  (generate-list alphas z-ivls)])
-      (for ([za     (in-list zs)]
-            [zb     (in-list (rest zs))]
-            [color : (List Real Real Real)  (in-cycle* colors)]
-            [style : Plot-Brush-Style  (in-cycle* styles)]
-            [alpha : Nonnegative-Real  (in-cycle* alphas)])
-        (send area put-brush color style)
-        (send area put-alpha alpha)
-        (for-2d-sample
-         (xa xb ya yb z1 z2 z3 z4) sample
-         (for ([poly  (in-list (heights->polys xa xb ya yb za zb z1 z2 z3 z4))])
-           (send area put-polygon (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) poly)))))
-      
-      ((contours-render-proc g levels samples contour-colors contour-widths contour-styles alphas #f)
-       area)
-      
-      (define n (- (length zs) 2))
-      (define contour-colors*
-        (append (list 0) (sequence-take (in-cycle* (generate-list contour-colors zs)) 0 n) (list 0)))
-      (define contour-widths*
-        (append (list 0) (sequence-take (in-cycle* (generate-list contour-widths zs)) 0 n) (list 0)))
-      (define contour-styles*
-        (append '(transparent) (sequence-take (in-cycle* (generate-list contour-styles zs)) 0 n)
-                '(transparent)))
-      
-      (cond [label  (interval-legend-entries
-                     label z-ivls ivl-labels
-                     colors styles colors '(1) '(transparent)
-                     contour-colors* contour-widths* contour-styles*
-                     (rest contour-colors*) (rest contour-widths*) (rest contour-styles*))]
-            [else   empty]))))
+       (List (U #f (-> Rect (Treeof legend-entry)))
+             2D-Render-Proc)))
+(define (make-contour-intervals-labels-and-renderer
+         g levels samples colors styles contour-colors contour-widths contour-styles alphas label)
+
+  (define last-rect       : (U #f Rect)     #f)
+  (define last-sample     : 2d-sample       (2d-sample '() '() #() #f #f))
+  (define last-z-ivls     : (Listof ivl)    empty)
+  (define last-zs         : (Listof Real)   empty)
+  (define last-ivl-labels : (Listof String) empty)
+
+  (define (calculate-zivls/labels [rect : Rect]) : (List 2d-sample (Listof ivl) (Listof Real) (Listof String))
+    (cond
+      [(equal? rect last-rect) (list last-sample last-z-ivls last-zs last-ivl-labels)]
+      [else
+       (match-define (vector x-ivl y-ivl) rect)
+       (define num (animated-samples samples))
+       (define sample (g (vector x-ivl y-ivl) (vector num num)))
+       (match-define (2d-sample xs ys zss z-min z-max) sample)
+       (set! last-rect rect)
+       (set! last-sample sample)
+       (cond
+         [(and z-min z-max)
+          (match-define (list (tick #{zs : (Listof Real)}
+                                    #{_ : (Listof Boolean)}
+                                    #{labels : (Listof String)})
+                              ...)
+            (contour-ticks (plot-z-ticks) (assert z-min values) (assert z-max values) levels #t))
+
+          (define-values (z-ivls ivl-labels)
+            (for/lists ([z-ivls : (Listof ivl)]
+                        [ivl-labels : (Listof String)]
+                        ) ([za  (in-list zs)]
+                           [zb  (in-list (rest zs))]
+                           [la  (in-list labels)]
+                           [lb  (in-list (rest labels))])
+              (values (ivl za zb) (format "[~a,~a]" la lb))))
+          
+          (set! last-z-ivls     z-ivls)
+          (set! last-zs         zs)
+          (set! last-ivl-labels ivl-labels)
+          (list sample z-ivls zs ivl-labels)]
+         [else
+          (set! last-z-ivls     empty)
+          (set! last-zs         empty)
+          (set! last-ivl-labels empty)
+          (list sample empty empty empty)])]))
+
+  (list
+   ;; Label function
+   (and label
+        (λ ([rect : Rect])
+          (match-define (list _ z-ivls zs ivl-labels)
+            (calculate-zivls/labels rect))
+          
+          (cond
+            [(empty? zs) empty]
+            [else
+             (let* ([colors  (map ->brush-color (generate-list colors z-ivls))]
+                    [styles  (map ->brush-style (generate-list styles z-ivls))])
+               (define n (- (length zs) 2))
+               (define contour-colors*
+                 (append (list 0) (sequence-take (in-cycle* (generate-list contour-colors zs)) 0 n) (list 0)))
+               (define contour-widths*
+                 (append (list 0) (sequence-take (in-cycle* (generate-list contour-widths zs)) 0 n) (list 0)))
+               (define contour-styles*
+                 (append '(transparent) (sequence-take (in-cycle* (generate-list contour-styles zs)) 0 n)
+                         '(transparent)))
+          
+               (interval-legend-entries
+                label z-ivls ivl-labels
+                colors styles colors '(1) '(transparent)
+                contour-colors* contour-widths* contour-styles*
+                (rest contour-colors*) (rest contour-widths*) (rest contour-styles*)))])))
+   ;; Render function
+   (λ (area)
+     (match-define (list sample z-ivls zs _)
+       (calculate-zivls/labels (send area get-bounds-rect)))
+     (unless (empty? zs)
+       (let* ([colors  (map ->brush-color (generate-list colors z-ivls))]
+              [styles  (map ->brush-style (generate-list styles z-ivls))]
+              [alphas  (generate-list alphas z-ivls)])
+         
+         (send area put-pen 0 1 'transparent)
+         (for ([za     (in-list zs)]
+               [zb     (in-list (rest zs))]
+               [color : (List Real Real Real)  (in-cycle* colors)]
+               [style : Plot-Brush-Style  (in-cycle* styles)]
+               [alpha : Nonnegative-Real  (in-cycle* alphas)])
+           (send area put-brush color style)
+           (send area put-alpha alpha)
+           (for-2d-sample
+            (xa xb ya yb z1 z2 z3 z4) sample
+            (for ([poly  (in-list (heights->polys xa xb ya yb za zb z1 z2 z3 z4))])
+              (send area put-polygon (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) poly)))))
+
+         (match-define (list _ contour-render-proc)
+           (make-contour-labels-and-renderer
+            g levels samples contour-colors contour-widths contour-styles alphas #f))
+
+         (contour-render-proc area))))))
 
 (:: contour-intervals
     (->* [(-> Real Real Real)]
@@ -266,7 +323,7 @@
      (define x-ivl (ivl x-min x-max))
      (define y-ivl (ivl y-min y-max))
      (define g (2d-function->sampler f (vector x-ivl y-ivl)))
-     (renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
-                 (contour-intervals-render-proc g levels samples colors styles
-                                                contour-colors contour-widths contour-styles
-                                                alphas label))]))
+     (apply renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
+            (make-contour-intervals-labels-and-renderer
+             g levels samples colors styles
+             contour-colors contour-widths contour-styles alphas label))]))

--- a/plot-lib/plot/private/plot2d/contour.rkt
+++ b/plot-lib/plot/private/plot2d/contour.rkt
@@ -79,17 +79,17 @@
                                 (Plot-Pen-Styles (Listof Real))
                                 (Alphas (Listof Real))
                                 (U String pict #f)
-                                (List (U #f (-> Rect (Treeof legend-entry)))
-                                      2D-Render-Proc)))
+                                (Values (U #f (-> Rect (Treeof legend-entry)))
+                                        2D-Render-Proc)))
 (define (make-contour-labels-and-renderer g levels samples colors widths styles alphas label)
   (define last-rect   : (U #f Rect)     #f)
   (define last-sample : 2d-sample       (2d-sample '() '() #() #f #f))
   (define last-zs     : (Listof Real)   empty)
   (define last-labels : (Listof String) empty)
 
-  (define (calculate-zs/labels [rect : Rect]) : (List 2d-sample (Listof Real) (Listof String))
+  (define (calculate-zs/labels [rect : Rect]) : (Values 2d-sample (Listof Real) (Listof String))
     (cond
-      [(equal? rect last-rect) (list last-sample last-zs last-labels)]
+      [(equal? rect last-rect) (values last-sample last-zs last-labels)]
       [else
        (match-define (vector x-ivl y-ivl) rect)
        (define num (animated-samples samples))
@@ -106,38 +106,41 @@
             (contour-ticks (plot-z-ticks) (assert z-min values) (assert z-max values) levels #f))
           (set! last-zs zs)
           (set! last-labels labels)
-          (list sample zs labels)]
+          (values sample zs labels)]
          [else
           (set! last-zs     empty)
           (set! last-labels empty)
-          (list sample empty empty)])]))
+          (values sample empty empty)])]))
 
-  (list
-   (and label (λ ([rect : Rect])
-                (match-define (list _ zs labels) (calculate-zs/labels rect))
-                (if (empty? zs)
-                    '()
-                    (line-legend-entries label zs labels colors widths styles))))
-   (λ (area)
-     (match-define (list sample zs _)
-       (calculate-zs/labels (send area get-bounds-rect)))
-     (unless (empty? zs)
-       (let* ([colors  (generate-list colors zs)]
-              [widths  (generate-list widths zs)]
-              [styles  (generate-list styles zs)]
-              [alphas  (generate-list alphas zs)])
-         (for ([z      (in-list zs)]
-               [color  (in-cycle* colors)]
-               [width : Nonnegative-Real  (in-cycle* widths)]
-               [style  (in-cycle* styles)]
-               [alpha : Nonnegative-Real  (in-cycle* alphas)])
-           (send area put-alpha alpha)
-           (send area put-pen color width style)
-           (for-2d-sample
-            (xa xb ya yb z1 z2 z3 z4) sample
-            (for ([line  (in-list (heights->lines xa xb ya yb z z1 z2 z3 z4))])
-              (match-define (list v1 v2) (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) line))
-              (send area put-line v1 v2)))))))))
+  (define label-proc
+    (and label (λ ([rect : Rect])
+                 (define-values (_ zs labels) (calculate-zs/labels rect))
+                 (if (empty? zs)
+                     '()
+                     (line-legend-entries label zs labels colors widths styles)))))
+  
+  (: render-proc 2D-Render-Proc)
+  (define (render-proc area)
+    (define-values (sample zs _) (calculate-zs/labels (send area get-bounds-rect)))
+    (unless (empty? zs)
+      (let* ([colors  (generate-list colors zs)]
+             [widths  (generate-list widths zs)]
+             [styles  (generate-list styles zs)]
+             [alphas  (generate-list alphas zs)])
+        (for ([z      (in-list zs)]
+              [color  (in-cycle* colors)]
+              [width : Nonnegative-Real  (in-cycle* widths)]
+              [style  (in-cycle* styles)]
+              [alpha : Nonnegative-Real  (in-cycle* alphas)])
+          (send area put-alpha alpha)
+          (send area put-pen color width style)
+          (for-2d-sample
+           (xa xb ya yb z1 z2 z3 z4) sample
+           (for ([line  (in-list (heights->lines xa xb ya yb z z1 z2 z3 z4))])
+             (match-define (list v1 v2) (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) line))
+             (send area put-line v1 v2)))))))
+  
+  (values label-proc render-proc))
 
 (:: contours
     (->* [(-> Real Real Real)]
@@ -171,9 +174,11 @@
      (define x-ivl (ivl x-min x-max))
      (define y-ivl (ivl y-min y-max))
      (define g (2d-function->sampler f (vector x-ivl y-ivl)))
-     (apply renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
-            (make-contour-labels-and-renderer
-             g levels samples colors widths styles alphas label))]))
+     (define-values (label-proc render-proc)
+       (make-contour-labels-and-renderer
+        g levels samples colors widths styles alphas label))
+     (renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
+                 label-proc render-proc)]))
 
 ;; ===================================================================================================
 ;; Contour intervals
@@ -184,8 +189,8 @@
        (Plot-Colors (Listof Real)) (Pen-Widths (Listof Real)) (Plot-Pen-Styles (Listof Real))
        (Alphas (Listof ivl))
        (U String pict #f)
-       (List (U #f (-> Rect (Treeof legend-entry)))
-             2D-Render-Proc)))
+       (Values (U #f (-> Rect (Treeof legend-entry)))
+               2D-Render-Proc)))
 (define (make-contour-intervals-labels-and-renderer
          g levels samples colors styles contour-colors contour-widths contour-styles alphas label)
 
@@ -195,9 +200,9 @@
   (define last-zs         : (Listof Real)   empty)
   (define last-ivl-labels : (Listof String) empty)
 
-  (define (calculate-zivls/labels [rect : Rect]) : (List 2d-sample (Listof ivl) (Listof Real) (Listof String))
+  (define (calculate-zivls/labels [rect : Rect]) : (Values 2d-sample (Listof ivl) (Listof Real) (Listof String))
     (cond
-      [(equal? rect last-rect) (list last-sample last-z-ivls last-zs last-ivl-labels)]
+      [(equal? rect last-rect) (values last-sample last-z-ivls last-zs last-ivl-labels)]
       [else
        (match-define (vector x-ivl y-ivl) rect)
        (define num (animated-samples samples))
@@ -225,66 +230,68 @@
           (set! last-z-ivls     z-ivls)
           (set! last-zs         zs)
           (set! last-ivl-labels ivl-labels)
-          (list sample z-ivls zs ivl-labels)]
+          (values sample z-ivls zs ivl-labels)]
          [else
           (set! last-z-ivls     empty)
           (set! last-zs         empty)
           (set! last-ivl-labels empty)
-          (list sample empty empty empty)])]))
+          (values sample empty empty empty)])]))
 
-  (list
-   ;; Label function
-   (and label
-        (λ ([rect : Rect])
-          (match-define (list _ z-ivls zs ivl-labels)
-            (calculate-zivls/labels rect))
+  (define label-proc
+    (and label
+         (λ ([rect : Rect])
+           (define-values (_ z-ivls zs ivl-labels)
+             (calculate-zivls/labels rect))
           
-          (cond
-            [(empty? zs) empty]
-            [else
-             (let* ([colors  (map ->brush-color (generate-list colors z-ivls))]
-                    [styles  (map ->brush-style (generate-list styles z-ivls))])
-               (define n (- (length zs) 2))
-               (define contour-colors*
-                 (append (list 0) (sequence-take (in-cycle* (generate-list contour-colors zs)) 0 n) (list 0)))
-               (define contour-widths*
-                 (append (list 0) (sequence-take (in-cycle* (generate-list contour-widths zs)) 0 n) (list 0)))
-               (define contour-styles*
-                 (append '(transparent) (sequence-take (in-cycle* (generate-list contour-styles zs)) 0 n)
-                         '(transparent)))
+           (cond
+             [(empty? zs) empty]
+             [else
+              (let* ([colors  (map ->brush-color (generate-list colors z-ivls))]
+                     [styles  (map ->brush-style (generate-list styles z-ivls))])
+                (define n (- (length zs) 2))
+                (define contour-colors*
+                  (append (list 0) (sequence-take (in-cycle* (generate-list contour-colors zs)) 0 n) (list 0)))
+                (define contour-widths*
+                  (append (list 0) (sequence-take (in-cycle* (generate-list contour-widths zs)) 0 n) (list 0)))
+                (define contour-styles*
+                  (append '(transparent) (sequence-take (in-cycle* (generate-list contour-styles zs)) 0 n)
+                          '(transparent)))
           
-               (interval-legend-entries
-                label z-ivls ivl-labels
-                colors styles colors '(1) '(transparent)
-                contour-colors* contour-widths* contour-styles*
-                (rest contour-colors*) (rest contour-widths*) (rest contour-styles*)))])))
-   ;; Render function
-   (λ (area)
-     (match-define (list sample z-ivls zs _)
-       (calculate-zivls/labels (send area get-bounds-rect)))
-     (unless (empty? zs)
-       (let* ([colors  (map ->brush-color (generate-list colors z-ivls))]
-              [styles  (map ->brush-style (generate-list styles z-ivls))]
-              [alphas  (generate-list alphas z-ivls)])
+                (interval-legend-entries
+                 label z-ivls ivl-labels
+                 colors styles colors '(1) '(transparent)
+                 contour-colors* contour-widths* contour-styles*
+                 (rest contour-colors*) (rest contour-widths*) (rest contour-styles*)))]))))
+
+  (: render-proc 2D-Render-Proc)
+  (define (render-proc area)
+    (define-values (sample z-ivls zs _)
+      (calculate-zivls/labels (send area get-bounds-rect)))
+    (unless (empty? zs)
+      (let* ([colors  (map ->brush-color (generate-list colors z-ivls))]
+             [styles  (map ->brush-style (generate-list styles z-ivls))]
+             [alphas  (generate-list alphas z-ivls)])
          
-         (send area put-pen 0 1 'transparent)
-         (for ([za     (in-list zs)]
-               [zb     (in-list (rest zs))]
-               [color : (List Real Real Real)  (in-cycle* colors)]
-               [style : Plot-Brush-Style  (in-cycle* styles)]
-               [alpha : Nonnegative-Real  (in-cycle* alphas)])
-           (send area put-brush color style)
-           (send area put-alpha alpha)
-           (for-2d-sample
-            (xa xb ya yb z1 z2 z3 z4) sample
-            (for ([poly  (in-list (heights->polys xa xb ya yb za zb z1 z2 z3 z4))])
-              (send area put-polygon (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) poly)))))
+        (send area put-pen 0 1 'transparent)
+        (for ([za     (in-list zs)]
+              [zb     (in-list (rest zs))]
+              [color : (List Real Real Real)  (in-cycle* colors)]
+              [style : Plot-Brush-Style  (in-cycle* styles)]
+              [alpha : Nonnegative-Real  (in-cycle* alphas)])
+          (send area put-brush color style)
+          (send area put-alpha alpha)
+          (for-2d-sample
+           (xa xb ya yb z1 z2 z3 z4) sample
+           (for ([poly  (in-list (heights->polys xa xb ya yb za zb z1 z2 z3 z4))])
+             (send area put-polygon (map (λ ([v : (Vectorof Real)]) (vector-take v 2)) poly)))))
 
-         (match-define (list _ contour-render-proc)
-           (make-contour-labels-and-renderer
-            g levels samples contour-colors contour-widths contour-styles alphas #f))
+        (define-values (_ contour-render-proc)
+          (make-contour-labels-and-renderer
+           g levels samples contour-colors contour-widths contour-styles alphas #f))
 
-         (contour-render-proc area))))))
+        (contour-render-proc area))))
+
+  (values label-proc render-proc))
 
 (:: contour-intervals
     (->* [(-> Real Real Real)]
@@ -323,7 +330,9 @@
      (define x-ivl (ivl x-min x-max))
      (define y-ivl (ivl y-min y-max))
      (define g (2d-function->sampler f (vector x-ivl y-ivl)))
-     (apply renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
-            (make-contour-intervals-labels-and-renderer
-             g levels samples colors styles
-             contour-colors contour-widths contour-styles alphas label))]))
+     (define-values (label-proc render-proc)
+       (make-contour-intervals-labels-and-renderer
+        g levels samples colors styles
+        contour-colors contour-widths contour-styles alphas label))
+     (renderer2d (vector x-ivl y-ivl) #f default-ticks-fun
+                 label-proc render-proc)]))

--- a/plot-lib/plot/private/plot2d/decoration.rkt
+++ b/plot-lib/plot/private/plot2d/decoration.rkt
@@ -35,9 +35,7 @@
     (define dist (+ radius (pen-gap)))
     (for ([t  (in-list x-ticks)] #:when (pre-tick-major? t))
       (match-define (tick x _ label) t)
-      (send area put-text label (vector x y) (if far? 'bottom 'top) 0 dist)))
-  
-  empty)
+      (send area put-text label (vector x y) (if far? 'bottom 'top) 0 dist))))
 
 (:: x-axis
     (->* [] [Real #:ticks? Boolean #:labels? Boolean #:far? Boolean #:alpha Nonnegative-Real]
@@ -52,7 +50,7 @@
     [(or (> alpha 1) (not (rational? alpha)))  (raise-keyword-error 'x-axis "real in [0,1]"
                                                                     '#:alpha alpha)]
     [else
-     (renderer2d #f #f #f (x-axis-render-proc y ticks? labels? far? alpha))]))
+     (renderer2d #f #f #f #f (x-axis-render-proc y ticks? labels? far? alpha))]))
 
 ;; ---------------------------------------------------------------------------------------------------
 
@@ -77,9 +75,7 @@
     (define dist (+ radius (pen-gap)))
     (for ([t  (in-list y-ticks)] #:when (pre-tick-major? t))
       (match-define (tick y _ label) t)
-      (send area put-text label (vector x y) (if far? 'left 'right) 0 dist)))
-  
-  empty)
+      (send area put-text label (vector x y) (if far? 'left 'right) 0 dist))))
 
 (:: y-axis
     (->* [] [Real #:ticks? Boolean #:labels? Boolean #:far? Boolean #:alpha Nonnegative-Real]
@@ -94,7 +90,7 @@
     [(or (> alpha 1) (not (rational? alpha)))  (raise-keyword-error 'y-axis "real in [0,1]"
                                                                     '#:alpha alpha)]
     [else
-     (renderer2d #f #f #f (y-axis-render-proc x ticks? labels? far? alpha))]))
+     (renderer2d #f #f #f #f (y-axis-render-proc x ticks? labels? far? alpha))]))
 
 (:: axes
     (->* []
@@ -195,8 +191,7 @@
 (define ((polar-axes-render-proc num ticks? labels? alpha) area)
   (send area put-alpha alpha)
   (when (num . > . 0) (draw-polar-axis-lines num area))
-  (when ticks? (draw-polar-axis-ticks (if (num . > . 0) num 12) labels? area))
-  empty)
+  (when ticks? (draw-polar-axis-ticks (if (num . > . 0) num 12) labels? area)))
 
 (:: polar-axes
     (->* [] [#:number Natural #:ticks? Boolean #:labels? Boolean #:alpha Nonnegative-Real]
@@ -209,7 +204,7 @@
     [(or (> alpha 1) (not (rational? alpha)))  (raise-keyword-error 'polar-axes "real in [0,1]"
                                                                     '#:alpha alpha)]
     [else
-     (renderer2d #f #f #f (polar-axes-render-proc num ticks? labels? alpha))]))
+     (renderer2d #f #f #f #f (polar-axes-render-proc num ticks? labels? alpha))]))
 
 ;; ===================================================================================================
 ;; Grid
@@ -223,8 +218,7 @@
     (for ([t  (in-list x-ticks)])
       (match-define (tick x major? _) t)
       (if major? (send area put-minor-pen) (send area put-minor-pen 'long-dash))
-      (send area put-line (vector x y-min) (vector x y-max))))
-  empty)
+      (send area put-line (vector x y-min) (vector x y-max)))))
 
 (: y-tick-lines-render-proc (-> 2D-Render-Proc))
 (define ((y-tick-lines-render-proc) area)
@@ -235,16 +229,15 @@
     (for ([t  (in-list y-ticks)])
       (match-define (tick y major? _) t)
       (if major? (send area put-minor-pen) (send area put-minor-pen 'long-dash))
-      (send area put-line (vector x-min y) (vector x-max y))))
-  empty)
+      (send area put-line (vector x-min y) (vector x-max y)))))
 
 (:: x-tick-lines (-> renderer2d))
 (define (x-tick-lines)
-  (renderer2d #f #f #f (x-tick-lines-render-proc)))
+  (renderer2d #f #f #f #f (x-tick-lines-render-proc)))
 
 (:: y-tick-lines (-> renderer2d))
 (define (y-tick-lines)
-  (renderer2d #f #f #f (y-tick-lines-render-proc)))
+  (renderer2d #f #f #f #f (y-tick-lines-render-proc)))
 
 (:: tick-grid (-> (Listof renderer2d)))
 (define (tick-grid)
@@ -284,9 +277,7 @@
     ; point
     (send area put-pen point-color point-line-width 'solid)
     (send area put-brush point-fill-color 'solid)
-    (send area put-glyphs (list v) point-sym point-size))
-  
-  empty)
+    (send area put-glyphs (list v) point-sym point-size)))
 
 (: pict-render-proc (-> pict (Vectorof Real)
                         Anchor
@@ -303,8 +294,7 @@
   ; point
   (send area put-pen point-color point-line-width 'solid)
   (send area put-brush point-fill-color 'solid)
-  (send area put-glyphs (list v) point-sym point-size)
-  empty)
+  (send area put-glyphs (list v) point-sym point-size))
 
 (:: point-label
     (->* [(Sequenceof Real)]
@@ -345,7 +335,7 @@
     [else
      (let ([v  (sequence-head-vector 'point-label v 2)])
        (match-define (vector x y) v)
-       (renderer2d (vector (ivl x x) (ivl y y)) #f #f
+       (renderer2d (vector (ivl x x) (ivl y y)) #f #f #f
                    (label-render-proc
                     label v color size face family anchor angle
                     point-color (cond [(eq? point-fill-color 'auto)  (->pen-color point-color)]
@@ -379,7 +369,7 @@
     [else 
      (let ([v (sequence-head-vector 'point-pict v 2)])
        (match-define (vector x y) v)
-       (renderer2d (vector (ivl x x) (ivl y y)) #f #f
+       (renderer2d (vector (ivl x x) (ivl y y)) #f #f #f
                    (pict-render-proc pict v anchor
                                      point-color (cond [(eq? point-fill-color 'auto)  (->pen-color point-color)]
                                                        [else  point-fill-color])

--- a/plot-lib/plot/private/plot2d/interval.rkt
+++ b/plot-lib/plot/private/plot2d/interval.rkt
@@ -18,12 +18,11 @@
                                   Plot-Color Nonnegative-Real Plot-Pen-Style
                                   Plot-Color Nonnegative-Real Plot-Pen-Style
                                   Nonnegative-Real
-                                  (U String pict #f)
                                   2D-Render-Proc))
 (define ((lines-interval-render-proc v1s v2s color style
                                      line1-color line1-width line1-style
                                      line2-color line2-width line2-style
-                                     alpha label)
+                                     alpha)
          area)
   (send area put-alpha alpha)
   (send area put-pen 0 0 'transparent)
@@ -34,12 +33,7 @@
   (send area put-lines v1s)
   
   (send area put-pen line2-color line2-width line2-style)
-  (send area put-lines v2s)
-  
-  (cond [label  (interval-legend-entry label color style 0 0 'transparent
-                                       line1-color line1-width line1-style
-                                       line2-color line2-width line2-style)]
-        [else  empty]))
+  (send area put-lines v2s))
 
 (:: lines-interval
     (->* [(Sequenceof (Sequenceof Real))
@@ -84,7 +78,7 @@
            [v2s  (sequence->listof-vector 'lines-interval v2s 2)])
        (define rvs (filter vrational? (append v1s v2s)))
        (cond
-         [(empty? rvs)  (renderer2d #f #f #f #f)]
+         [(empty? rvs)  empty-renderer2d]
          [else
           (match-define (list (vector #{rxs : (Listof Real)} #{rys : (Listof Real)}) ...) rvs)
           (let ([x-min  (if x-min x-min (apply min* rxs))]
@@ -92,10 +86,14 @@
                 [y-min  (if y-min y-min (apply min* rys))]
                 [y-max  (if y-max y-max (apply max* rys))])
             (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun
+                        (and label (λ (_)
+                                     (interval-legend-entry label color style 0 0 'transparent
+                                                            line1-color line1-width line1-style
+                                                            line2-color line2-width line2-style)))
                         (lines-interval-render-proc v1s v2s color style
                                                     line1-color line1-width line1-style
                                                     line2-color line2-width line2-style
-                                                    alpha label)))]))]))
+                                                    alpha)))]))]))
 
 (:: parametric-interval
     (->* [(-> Real (Sequenceof Real)) (-> Real (Sequenceof Real)) Real Real]
@@ -217,12 +215,11 @@
                                      Plot-Color Nonnegative-Real Plot-Pen-Style
                                      Plot-Color Nonnegative-Real Plot-Pen-Style
                                      Nonnegative-Real
-                                     (U String pict #f)
                                      2D-Render-Proc))
 (define ((function-interval-render-proc f1 f2 samples color style
                                         line1-color line1-width line1-style
                                         line2-color line2-width line2-style
-                                        alpha label)
+                                        alpha)
          area)
   (match-define (vector x-ivl y-ivl) (send area get-bounds-rect))
   (match-define (sample x1s y1s _ _) (f1 x-ivl samples))
@@ -233,7 +230,7 @@
   ((lines-interval-render-proc v1s v2s color style
                                line1-color line1-width line1-style
                                line2-color line2-width line2-style
-                               alpha label)
+                               alpha)
    area))
 
 (:: function-interval
@@ -285,10 +282,14 @@
      (renderer2d (vector x-ivl y-ivl)
                  (function-interval-bounds-fun g1 g2 samples)
                  default-ticks-fun
+                 (and label (λ (_)
+                              (interval-legend-entry label color style 0 0 'transparent
+                                                     line1-color line1-width line1-style
+                                                     line2-color line2-width line2-style)))
                  (function-interval-render-proc g1 g2 samples color style
                                                 line1-color line1-width line1-style
                                                 line2-color line2-width line2-style
-                                                alpha label))]))
+                                                alpha))]))
 
 ;; ===================================================================================================
 ;; Inverse function
@@ -298,12 +299,11 @@
                                     Plot-Color Nonnegative-Real Plot-Pen-Style
                                     Plot-Color Nonnegative-Real Plot-Pen-Style
                                     Nonnegative-Real
-                                    (U String pict #f)
                                     2D-Render-Proc))
 (define ((inverse-interval-render-proc f1 f2 samples color style
                                        line1-color line1-width line1-style
                                        line2-color line2-width line2-style
-                                       alpha label)
+                                       alpha)
          area)
   (match-define (vector x-ivl y-ivl) (send area get-bounds-rect))
   (match-define (sample y1s x1s _ _) (f1 y-ivl samples))
@@ -314,7 +314,7 @@
   ((lines-interval-render-proc v1s v2s color style
                                line1-color line1-width line1-style
                                line2-color line2-width line2-style
-                               alpha label)
+                               alpha)
    area))
 
 (:: inverse-interval
@@ -366,7 +366,11 @@
      (renderer2d (vector x-ivl y-ivl)
                  (inverse-interval-bounds-fun g1 g2 samples)
                  default-ticks-fun
+                 (and label (λ (_)
+                              (interval-legend-entry label color style 0 0 'transparent
+                                                     line1-color line1-width line1-style
+                                                     line2-color line2-width line2-style)))
                  (inverse-interval-render-proc g1 g2 samples color style
                                                line1-color line1-width line1-style
                                                line2-color line2-width line2-style
-                                               alpha label))]))
+                                               alpha))]))

--- a/plot-lib/plot/private/plot2d/line.rkt
+++ b/plot-lib/plot/private/plot2d/line.rkt
@@ -17,15 +17,11 @@
 (: lines-render-proc (-> (Listof (Vectorof Real))
                          Plot-Color Nonnegative-Real Plot-Pen-Style
                          Nonnegative-Real
-                         (U String pict #f)
                          2D-Render-Proc))
-(define ((lines-render-proc vs color width style alpha label) area)
+(define ((lines-render-proc vs color width style alpha) area)
   (send area put-alpha alpha)
   (send area put-pen color width style)
-  (send area put-lines vs)
-  
-  (cond [label  (line-legend-entry label color width style)]
-        [else   empty]))
+  (send area put-lines vs))
 
 (:: lines
     (->* [(Sequenceof (Sequenceof Real))]
@@ -56,7 +52,7 @@
     [else
      (let ([vs  (sequence->listof-vector 'lines vs 2)])
        (define rvs (filter vrational? vs))
-       (cond [(empty? rvs)  (renderer2d #f #f #f #f)]
+       (cond [(empty? rvs)  empty-renderer2d]
              [else
               (match-define (list (vector #{rxs : (Listof Real)} #{rys : (Listof Real)}) ...) rvs)
               (let ([x-min  (if x-min x-min (apply min* rxs))]
@@ -64,7 +60,8 @@
                     [y-min  (if y-min y-min (apply min* rys))]
                     [y-max  (if y-max y-max (apply max* rys))])
                 (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun
-                            (lines-render-proc vs color width style alpha label)))]))]))
+                            (and label (λ (_) (line-legend-entry label color width style)))
+                            (lines-render-proc vs color width style alpha)))]))]))
 
 (:: parametric
     (->* [(-> Real (Sequenceof Real)) Real Real]
@@ -154,9 +151,8 @@
                         Nonnegative-Real
                         Plot-Pen-Style
                         Nonnegative-Real
-                        (U String pict #f)
                         2D-Render-Proc))
-(define ((rule-render-proc v v-min v-max h/v color width style alpha label) area)
+(define ((rule-render-proc v v-min v-max h/v color width style alpha) area)
   (match-define (vector (ivl x-min x-max) (ivl y-min y-max)) (send area get-bounds-rect))
   ;; This is the error that `get-bounds-rect` should raise
   (unless (and x-min x-max y-min y-max)
@@ -167,10 +163,7 @@
   (send area put-pen color width style 'butt)
   (case h/v
     [(h) (send area put-line (vector (or v-min x-min) v) (vector (or v-max x-max) v))]
-    [(v) (send area put-line (vector v (or v-min y-min)) (vector v (or v-max y-max)))])
-
-  (cond [label  (line-legend-entry label color width style)]
-        [else   empty]))
+    [(v) (send area put-line (vector v (or v-min y-min)) (vector v (or v-max y-max)))]))
 
 (:: vrule
     (->* [Real]
@@ -196,7 +189,8 @@
     [(or (> alpha 1) (not (rational? alpha)))  (fail/kw "real in [0,1]" '#:alpha alpha)]
     [else
       (renderer2d #f #f default-ticks-fun
-                  (rule-render-proc x y-min y-max 'v color width style alpha label))]))
+                  (and label (λ (_) (line-legend-entry label color width style)))
+                  (rule-render-proc x y-min y-max 'v color width style alpha))]))
 
 (:: hrule
     (->* [Real]
@@ -222,7 +216,8 @@
     [(or (> alpha 1) (not (rational? alpha)))  (fail/kw "real in [0,1]" '#:alpha alpha)]
     [else
       (renderer2d #f #f default-ticks-fun
-                  (rule-render-proc y x-min x-max 'h color width style alpha label))]))
+                  (and label (λ (_) (line-legend-entry label color width style)))
+                  (rule-render-proc y x-min x-max 'h color width style alpha))]))
 
 ;; ===================================================================================================
 ;; Function
@@ -230,18 +225,14 @@
 (: function-render-proc (-> Sampler Positive-Integer
                             Plot-Color Nonnegative-Real Plot-Pen-Style
                             Nonnegative-Real
-                            (U String pict #f)
                             2D-Render-Proc))
-(define ((function-render-proc f samples color width style alpha label) area)
+(define ((function-render-proc f samples color width style alpha) area)
   (match-define (vector x-ivl y-ivl) (send area get-bounds-rect))
   (match-define (sample xs ys y-min y-max) (f x-ivl samples))
   
   (send area put-alpha alpha)
   (send area put-pen color width style)
-  (send area put-lines (map (λ ([x : Real] [y : Real]) (vector x y)) xs ys))
-  
-  (cond [label  (line-legend-entry label color width style)]
-        [else   empty]))
+  (send area put-lines (map (λ ([x : Real] [y : Real]) (vector x y)) xs ys)))
 
 (:: function
     (->* [(-> Real Real)]
@@ -279,7 +270,8 @@
        (renderer2d (vector x-ivl y-ivl)
                    (function-bounds-fun f samples)
                    default-ticks-fun
-                   (function-render-proc f samples color width style alpha label)))]))
+                   (and label (λ (_) (line-legend-entry label color width style)))
+                   (function-render-proc f samples color width style alpha)))]))
 
 ;; ===================================================================================================
 ;; Inverse function
@@ -287,18 +279,14 @@
 (: inverse-render-proc (-> Sampler Positive-Integer
                            Plot-Color Nonnegative-Real Plot-Pen-Style
                            Nonnegative-Real
-                           (U String pict #f)
                            2D-Render-Proc))
-(define ((inverse-render-proc f samples color width style alpha label) area)
+(define ((inverse-render-proc f samples color width style alpha) area)
   (match-define (vector x-ivl y-ivl) (send area get-bounds-rect))
   (match-define (sample ys xs x-min x-max) (f y-ivl samples))
   
   (send area put-alpha alpha)
   (send area put-pen color width style)
-  (send area put-lines (map (λ ([x : Real] [y : Real]) (vector x y)) xs ys))
-  
-  (cond [label  (line-legend-entry label color width style)]
-        [else   empty]))
+  (send area put-lines (map (λ ([x : Real] [y : Real]) (vector x y)) xs ys)))
 
 (: inverse
    (->* [(-> Real Real)]
@@ -336,7 +324,8 @@
      (renderer2d (vector x-ivl y-ivl)
                  (inverse-bounds-fun g samples)
                  default-ticks-fun
-                 (inverse-render-proc g samples color width style alpha label))]))
+                 (and label (λ (_) (line-legend-entry label color width style)))
+                 (inverse-render-proc g samples color width style alpha))]))
 
 ;; ===================================================================================================
 ;; Kernel density estimation

--- a/plot-lib/plot/private/plot2d/point.rkt
+++ b/plot-lib/plot/private/plot2d/point.rkt
@@ -23,15 +23,12 @@
 (: points-render-fun (-> (Listof (Vectorof Real)) Point-Sym
                          Plot-Color Plot-Color Nonnegative-Real Nonnegative-Real
                          Nonnegative-Real
-                         (U String pict #f)
                          2D-Render-Proc))
-(define ((points-render-fun vs sym color fill-color size line-width alpha label) area)
+(define ((points-render-fun vs sym color fill-color size line-width alpha) area)
   (send area put-alpha alpha)
   (send area put-pen color line-width 'solid)
   (send area put-brush fill-color 'solid)
-  (send area put-glyphs vs sym size)
-  
-  (if label (point-legend-entry label sym color fill-color size line-width) empty))
+  (send area put-glyphs vs sym size))
 
 (:: points
     (->* [(Sequenceof (Sequenceof Real))]
@@ -71,7 +68,7 @@
      (let* ([vs  (sequence->listof-vector 'points vs 2)]
             [vs  (filter vrational? vs)])
        (cond
-         [(empty? vs)  (renderer2d #f #f #f #f)]
+         [(empty? vs)  empty-renderer2d]
          [else
           (unless (= 0 x-jitter y-jitter)
             (points-apply-jitters vs (vector x-jitter y-jitter) #:ivls (vector (ivl x-min x-max) (ivl y-min y-max))))
@@ -83,8 +80,9 @@
                 [fill-color  (if (eq? fill-color 'auto) (->pen-color color) fill-color)])
             (renderer2d
              (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun
+             (and label (λ (_) (point-legend-entry label sym color fill-color size line-width)))
              (points-render-fun vs sym color fill-color
-                                size line-width alpha label)))]))]))
+                                size line-width alpha)))]))]))
 
 ;; ===================================================================================================
 ;; Vector fields
@@ -94,62 +92,56 @@
        Positive-Integer (U Real 'auto 'normalized)
        Plot-Color Nonnegative-Real Plot-Pen-Style
        Nonnegative-Real
-       (U String pict #f)
        2D-Render-Proc))
-(define ((vector-field-render-fun f samples scale color line-width line-style alpha label) area)
+(define ((vector-field-render-fun f samples scale color line-width line-style alpha) area)
   (match-define (vector (ivl x-min x-max) (ivl y-min y-max)) (send area get-bounds-rect))
   
-  (cond
-    [(and x-min x-max y-min y-max)
-     (define xs0 (linear-seq x-min x-max samples #:start? #t #:end? #t))
-     (define ys0 (linear-seq y-min y-max samples #:start? #t #:end? #t))
+  (when (and x-min x-max y-min y-max)
+    (define xs0 (linear-seq x-min x-max samples #:start? #t #:end? #t))
+    (define ys0 (linear-seq y-min y-max samples #:start? #t #:end? #t))
      
-     (define-values (xs ys dxs dys angles mags)
-       (for*/lists ([xs : (Listof Real)]
-                    [ys : (Listof Real)]
-                    [dxs : (Listof Real)]
-                    [dys : (Listof Real)]
-                    [angles : (Listof Real)]
-                    [mags : (Listof Nonnegative-Real)]
-                    ) ([x   (in-list xs0)]
-                       [y   (in-list ys0)]
-                       [dv  (in-value (f x y))] #:when (vrational? dv))
-         (match-define (vector dx dy) dv)
-         (values x y dx dy (atan2 dy dx) (sqrt (+ (sqr dx) (sqr dy))))))
+    (define-values (xs ys dxs dys angles mags)
+      (for*/lists ([xs : (Listof Real)]
+                   [ys : (Listof Real)]
+                   [dxs : (Listof Real)]
+                   [dys : (Listof Real)]
+                   [angles : (Listof Real)]
+                   [mags : (Listof Nonnegative-Real)]
+                   ) ([x   (in-list xs0)]
+                      [y   (in-list ys0)]
+                      [dv  (in-value (f x y))] #:when (vrational? dv))
+        (match-define (vector dx dy) dv)
+        (values x y dx dy (atan2 dy dx) (sqrt (+ (sqr dx) (sqr dy))))))
      
-     (cond [(empty? xs)  empty]
-           [else (define box-x-size (/ (- x-max x-min) samples))
-                 (define box-y-size (/ (- y-max y-min) samples))
+    (unless (empty? xs)
+      (define box-x-size (/ (- x-max x-min) samples))
+      (define box-y-size (/ (- y-max y-min) samples))
                  
-                 (define new-mags
-                   (match scale
-                     [(? real?)  (map (λ ([mag : Real]) (* scale mag)) mags)]
-                     ['normalized  (define box-size (min box-x-size box-y-size))
-                                   (build-list (length dxs) (λ _ box-size))]
-                     ['auto
-                      ;; When all dxs or dys are (exact) zero, the calculation of scale
-                      ;; will raise a 'division by zero' error. If we convert the values
-                      ;; to flonums, the partial result will be +inf.0, and the correct
-                      ;; scale can be calculated.
-                      (define dx-max (real->double-flonum (apply max (map abs dxs))))
-                      (define dy-max (real->double-flonum (apply max (map abs dys))))
-                      (define scale (min (/ box-x-size dx-max)
-                                         (/ box-y-size dy-max)))
-                      (map (λ ([mag : Real]) (* scale mag)) mags)]))
+      (define new-mags
+        (match scale
+          [(? real?)  (map (λ ([mag : Real]) (* scale mag)) mags)]
+          ['normalized  (define box-size (min box-x-size box-y-size))
+                        (build-list (length dxs) (λ _ box-size))]
+          ['auto
+           ;; When all dxs or dys are (exact) zero, the calculation of scale
+           ;; will raise a 'division by zero' error. If we convert the values
+           ;; to flonums, the partial result will be +inf.0, and the correct
+           ;; scale can be calculated.
+           (define dx-max (real->double-flonum (apply max (map abs dxs))))
+           (define dy-max (real->double-flonum (apply max (map abs dys))))
+           (define scale (min (/ box-x-size dx-max)
+                              (/ box-y-size dy-max)))
+           (map (λ ([mag : Real]) (* scale mag)) mags)]))
                  
-                 (send area put-alpha alpha)
-                 (send area put-pen color line-width line-style)
-                 (for ([x      (in-list xs)]
-                       [y      (in-list ys)]
-                       [angle  (in-list angles)]
-                       [mag    (in-list new-mags)])
-                   (send area put-arrow
-                         (vector x y)
-                         (vector (+ x (* mag (cos angle))) (+ y (* mag (sin angle))))))
-                 
-                 (cond [label  (arrow-legend-entry label color line-width line-style)]
-                       [else   empty])])]
-    [else  empty]))
+      (send area put-alpha alpha)
+      (send area put-pen color line-width line-style)
+      (for ([x      (in-list xs)]
+            [y      (in-list ys)]
+            [angle  (in-list angles)]
+            [mag    (in-list new-mags)])
+        (send area put-arrow
+              (vector x y)
+              (vector (+ x (* mag (cos angle))) (+ y (* mag (sin angle)))))))))
 
 (:: vector-field
     (->* [(U (-> Real Real (Sequenceof Real))
@@ -186,8 +178,9 @@
     [else
      (let ([f  (fix-vector-field-fun 'vector-field f)])
        (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun
+                   (and label (λ (_) (arrow-legend-entry label color line-width line-style)))
                    (vector-field-render-fun
-                    f samples scale color line-width line-style alpha label)))]))
+                    f samples scale color line-width line-style alpha)))]))
 
 ;; ===================================================================================================
 ;; Error bars
@@ -212,9 +205,7 @@
       (define v2 (maybe-invert x (+ y h)))
       (send area put-line v1 v2)
       (send area put-tick v1 radius angle)
-      (send area put-tick v2 radius angle)))
-  
-  empty)
+      (send area put-tick v2 radius angle))))
 
 (:: error-bars
     (->* [(Sequenceof (Sequenceof Real))]
@@ -247,7 +238,7 @@
     [else
      (let* ([bars  (sequence->listof-vector 'error-bars bars 3)]
             [bars  (filter vrational? bars)])
-       (cond [(empty? bars)  (renderer2d #f #f #f #f)]
+       (cond [(empty? bars)  empty-renderer2d]
              [else
               (match-define (list (vector #{xs : (Listof Real)}
                                           #{ys : (Listof Real)}
@@ -262,8 +253,7 @@
                 (define maybe-invert (if invert? (λ (x y) (vector y x)) vector))
                 (renderer2d
                  (maybe-invert (ivl x-min x-max) (ivl y-min y-max))
-                 #f
-                 default-ticks-fun
+                 #f default-ticks-fun #f
                  (error-bars-render-fun xs ys hs
                                         color line-width line-style width alpha invert?)))]))]))
 
@@ -295,8 +285,7 @@
                   (send area put-line v2 v4)
                   (send area put-line v1 v3)
                   (send area put-brush up-color 'solid)
-                  (send area put-rect r1)]))
-  empty)
+                  (send area put-rect r1)])))
 
 (:: candlesticks
     (->* [(Sequenceof (Sequenceof Real))]
@@ -329,7 +318,7 @@
     [else
      (let* ([candles  (sequence->listof-vector 'candlesticks candles 5)]
             [candles  (filter vrational? candles)])
-       (cond [(empty? candles)  (renderer2d #f #f #f #f)]
+       (cond [(empty? candles)  empty-renderer2d]
              [else
               (match-define (list (vector #{xs : (Listof Real)}
                                           #{opens : (Listof Real)}
@@ -342,6 +331,6 @@
                     [x-max  (if x-max x-max (+ (apply max* xs) width))]
                     [y-min  (if y-min y-min (apply min* lows))]
                     [y-max  (if y-max y-max (apply max* highs))])
-                (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun
+                (renderer2d (vector (ivl x-min x-max) (ivl y-min y-max)) #f default-ticks-fun #f
                             (candlesticks-render-fun xs opens highs lows closes
                                                      up-color down-color line-width line-style width alpha)))]))]))

--- a/plot-lib/plot/private/plot2d/renderer.rkt
+++ b/plot-lib/plot/private/plot2d/renderer.rkt
@@ -1,7 +1,6 @@
 #lang typed/racket/base
 
-(require typed/racket/class racket/match
-         "../common/plot-element.rkt"
+(require "../common/plot-element.rkt"
          "../common/types.rkt"
          "../common/type-doc.rkt"
          "../common/math.rkt"

--- a/plot-lib/plot/private/plot2d/renderer.rkt
+++ b/plot-lib/plot/private/plot2d/renderer.rkt
@@ -1,12 +1,18 @@
 #lang typed/racket/base
 
-(require "../common/plot-element.rkt"
+(require typed/racket/class racket/match
+         "../common/plot-element.rkt"
          "../common/types.rkt"
          "../common/type-doc.rkt"
+         "../common/math.rkt"
          "plot-area.rkt")
 
 (provide (all-defined-out))
 
-(deftype 2D-Render-Proc (-> (Instance 2D-Plot-Area%) (Treeof legend-entry)))
+(deftype 2D-Render-Proc (-> (Instance 2D-Plot-Area%) Void))
 
-(struct renderer2d plot-element ([render-proc : (U #f 2D-Render-Proc)]) #:transparent)
+(struct renderer2d plot-element ([label : (U #f (-> Rect (Treeof legend-entry)))]
+                                 [render-proc : (U #f 2D-Render-Proc)])
+  #:transparent)
+
+(define empty-renderer2d (renderer2d #f #f #f #f #f))

--- a/plot-lib/plot/private/plot3d/arrows.rkt
+++ b/plot-lib/plot/private/plot3d/arrows.rkt
@@ -16,26 +16,19 @@
        Plot-Color Nonnegative-Real Plot-Pen-Style
        Nonnegative-Real
        (U (List '= Nonnegative-Real) Nonnegative-Real) Nonnegative-Real
-       (U String pict #f)
        3D-Render-Proc))
 (define ((arrows3d-render-fun vs
                               color line-width line-style
                               alpha
-                              arrow-head-size-or-scale arrow-head-angle
-                              label) area)
+                              arrow-head-size-or-scale arrow-head-angle) area)
   (match-define (vector (ivl x-min x-max) (ivl y-min y-max) (ivl z-min z-max)) (send area get-bounds-rect))
   
-  (cond
-    [(and x-min x-max y-min y-max z-min z-max)  
+  (when (and x-min x-max y-min y-max z-min z-max)  
      (send area put-alpha alpha)
      (send area put-pen color line-width line-style)
      (send area put-arrow-head arrow-head-size-or-scale arrow-head-angle)
      (for ([x (in-list vs)])
-       (send area put-arrow (car x) (cdr x) #t))
-     (cond [label  (arrow-legend-entry label color line-width line-style)]
-           [else   empty])]
-    [else  empty])
-  )
+       (send area put-arrow (car x) (cdr x) #t))))
 
 
 (define-type LVof (All (A) (U (Listof A)(Vectorof A))))
@@ -120,14 +113,14 @@
          (filter vrational? (append p1 p2))))
 
      (cond
-       [(empty? rvs) (renderer3d #f #f #f #f)]
+       [(empty? rvs) empty-renderer3d]
        [else
         (define-values (x- x+ y- y+ z- z+) (get-bounds x-min x-max y-min y-max z-min z-max rvs))
         (renderer3d (vector (ivl x- x+) (ivl y- y+) (ivl z- z+)) #f default-ticks-fun
+                    (and label (λ (_) (arrow-legend-entry label color width style)))
                     (arrows3d-render-fun vs*
                                          color width style alpha
-                                         arrow-head-size-or-scale arrow-head-angle
-                                         label))])]))
+                                         arrow-head-size-or-scale arrow-head-angle))])]))
 
 
 (define (get-bounds [x-min : (Option Real)][x-max : (Option Real)]

--- a/plot-lib/plot/private/plot3d/contour.rkt
+++ b/plot-lib/plot/private/plot3d/contour.rkt
@@ -89,38 +89,26 @@
                                         (Values (U #f (-> Rect (Treeof legend-entry)))
                                                 3D-Render-Proc)))
 (define (make-contours3d-label-and-render f levels samples colors widths styles alphas label)
-  (define last-rect   : (U #f Rect)     #f)
-  (define last-zs     : (Listof Real)   empty)
-  (define last-sample : 2d-sample       (2d-sample '() '() #() #f #f))
-  (define last-labels : (Listof String) empty)
-  (define (update! [rect   : Rect]
-                   [sample : 2d-sample       (2d-sample '() '() #() #f #f)]
-                   [zs     : (Listof Real)   empty]
-                   [labels : (Listof String) empty])
-    (set! last-rect   rect)
-    (set! last-sample sample)
-    (set! last-zs     zs)
-    (set! last-labels labels))
-  
+  ;; g is a 2D-sampler, which is a memoized proc. Recalculation here should be cheap.
+  ;; if we memoize here based on rect, smooth interactions are disabled (because of the call to `plot-z-ticks`)
   (define (calculate-zs/labels [rect : Rect]) : (Values 2d-sample (Listof Real) (Listof String))
-    (unless (equal? rect last-rect)
-      (match-define (vector x-ivl y-ivl z-ivl) rect)
-      (match-define (ivl x-min x-max) x-ivl)
-      (match-define (ivl y-min y-max) y-ivl)
-      (match-define (ivl z-min z-max) z-ivl)
-      (cond
-        [(and z-min z-max)
-         (define num (animated-samples samples))
-         (define sample (f (vector x-ivl y-ivl) (vector num num)))
-         ;; can't use the actual z ticks because some or all could be collapsed
-         (match-define (list (tick #{zs : (Listof Real)}
-                                   #{_ : (Listof Boolean)}
-                                   #{labels : (Listof String)})
-                             ...)
-           (contour-ticks (plot-z-ticks) z-min z-max levels #f))
-         (update! rect sample zs labels)]
-        [else (update! rect)]))
-    (values last-sample last-zs last-labels))
+    (match-define (vector x-ivl y-ivl z-ivl) rect)
+    (match-define (ivl x-min x-max) x-ivl)
+    (match-define (ivl y-min y-max) y-ivl)
+    (match-define (ivl z-min z-max) z-ivl)
+    (cond
+      [(and z-min z-max)
+       (define num (animated-samples samples))
+       (define sample (f (vector x-ivl y-ivl) (vector num num)))
+       ;; can't use the actual z ticks because some or all could be collapsed
+       (match-define (list (tick #{zs : (Listof Real)}
+                                 #{_ : (Listof Boolean)}
+                                 #{labels : (Listof String)})
+                           ...)
+         (contour-ticks (plot-z-ticks) z-min z-max levels #f))
+       (values sample zs labels)]
+      [else
+       (values (2d-sample '() '() #() #f #f) empty empty)]))
 
   (define label-proc
     (and label
@@ -227,51 +215,36 @@
 (define (make-contour-intervals3d-label-and-renderer
           f levels samples colors styles line-colors line-widths line-styles
           contour-colors contour-widths contour-styles alphas label)
-  (define last-rect   : (U #f Rect)     #f)
-  (define last-zs     : (Listof Real)   empty)
-  (define last-zivls  : (Listof ivl)    empty)
-  (define last-sample : 2d-sample       (2d-sample '() '() #() #f #f))
-  (define last-labels : (Listof String) empty)
-  (define (update! [rect   : Rect]
-                   [sample : 2d-sample       (2d-sample '() '() #() #f #f)]
-                   [zivls  : (Listof ivl)    empty]
-                   [zs     : (Listof Real)   empty]
-                   [labels : (Listof String) empty])
-    (set! last-rect   rect)
-    (set! last-sample sample)
-    (set! last-zivls  zivls)
-    (set! last-zs     zs)
-    (set! last-labels labels))
-  
+  ;; g is a 2D-sampler, which is a memoized proc. Recalculation here should be cheap.
+  ;; if we memoize here based on rect, smooth interactions are disabled (because of the call to `plot-z-ticks`)
   (define (calculate-zivls/labels [rect : Rect]) : (Values 2d-sample (Listof ivl) (Listof Real) (Listof String))
-    (unless (equal? rect last-rect)
-      (match-define (vector x-ivl y-ivl z-ivl) rect)
-      (match-define (ivl x-min x-max) x-ivl)
-      (match-define (ivl y-min y-max) y-ivl)
-      (match-define (ivl z-min z-max) z-ivl)
-      (cond
-        [(and z-min z-max)
-         (define num (animated-samples samples))
-         (define sample (f (vector x-ivl y-ivl) (vector num num)))
-         ;; can't use the actual z ticks because some or all could be collapsed
-         (match-define (list (tick #{zs : (Listof Real)}
-                                   #{_ : (Listof Boolean)}
-                                   #{labels : (Listof String)})
-                             ...)
-           (contour-ticks (plot-z-ticks) z-min z-max levels #t))
+    (match-define (vector x-ivl y-ivl z-ivl) rect)
+    (match-define (ivl x-min x-max) x-ivl)
+    (match-define (ivl y-min y-max) y-ivl)
+    (match-define (ivl z-min z-max) z-ivl)
+    (cond
+      [(and z-min z-max)
+       (define num (animated-samples samples))
+       (define sample (f (vector x-ivl y-ivl) (vector num num)))
+       ;; can't use the actual z ticks because some or all could be collapsed
+       (match-define (list (tick #{zs : (Listof Real)}
+                                 #{_ : (Listof Boolean)}
+                                 #{labels : (Listof String)})
+                           ...)
+         (contour-ticks (plot-z-ticks) z-min z-max levels #t))
      
-         (define-values (z-ivls ivl-labels)
-           (for/lists ([z-ivls : (Listof ivl)]
-                       [ivl-labels : (Listof String)]
-                       ) ([za  (in-list zs)]
-                          [zb  (in-list (rest zs))]
-                          [la  (in-list labels)]
-                          [lb  (in-list (rest labels))])
-             (values (ivl za zb) (format "[~a,~a]" la lb))))
+       (define-values (z-ivls ivl-labels)
+         (for/lists ([z-ivls : (Listof ivl)]
+                     [ivl-labels : (Listof String)]
+                     ) ([za  (in-list zs)]
+                        [zb  (in-list (rest zs))]
+                        [la  (in-list labels)]
+                        [lb  (in-list (rest labels))])
+           (values (ivl za zb) (format "[~a,~a]" la lb))))
           
-         (update! rect sample z-ivls zs ivl-labels)]
-        [else (update! rect)]))
-    (values last-sample last-zivls last-zs last-labels))
+       (values sample z-ivls zs ivl-labels)]
+      [else
+       (values (2d-sample '() '() #() #f #f) empty empty empty)]))
 
   (define label-proc
     (and label

--- a/plot-lib/plot/private/plot3d/contour.rkt
+++ b/plot-lib/plot/private/plot3d/contour.rkt
@@ -14,9 +14,8 @@
 (: isoline3d-render-proc (-> 2D-Sampler Real Positive-Integer
                              Plot-Color Nonnegative-Real Plot-Pen-Style
                              Nonnegative-Real
-                             (U String pict #f)
                              3D-Render-Proc))
-(define ((isoline3d-render-proc f z samples color width style alpha label) area)
+(define ((isoline3d-render-proc f z samples color width style alpha) area)
   (match-define (vector x-ivl y-ivl z-ivl) (send area get-bounds-rect))
   (match-define (ivl z-min z-max) z-ivl)
   (define num (animated-samples samples))
@@ -30,9 +29,7 @@
      (for ([line  (in-list (heights->lines xa xb ya yb z z1 z2 z3 z4))])
        (match-define (list v1 v2) line)
        (send area put-line v1 v2))))
-  
-  (cond [label  (line-legend-entry label color width style)]
-        [else   empty]))
+  (void))
 
 (:: isoline3d
     (->* [(-> Real Real Real) Real]
@@ -77,54 +74,92 @@
        (define g (2d-function->sampler f (vector x-ivl y-ivl)))
        (renderer3d (vector x-ivl y-ivl z-ivl)
                    #f default-ticks-fun
-                   (isoline3d-render-proc g z samples color width style alpha label)))]))
+                   (and label (λ (_) (line-legend-entry label color width style)))
+                   (isoline3d-render-proc g z samples color width style alpha)))]))
 
 ;; ===================================================================================================
 ;; Contour lines in 3D (using marching squares)
 
-(: contours3d-render-proc (-> 2D-Sampler Contour-Levels Positive-Integer
-                              (Plot-Colors (Listof Real))
-                              (Pen-Widths (Listof Real))
-                              (Plot-Pen-Styles (Listof Real))
-                              (Alphas (Listof Real))
-                              (U String pict #f)
-                              3D-Render-Proc))
-(define ((contours3d-render-proc f levels samples colors widths styles alphas label) area)
-  (match-define (vector x-ivl y-ivl z-ivl) (send area get-bounds-rect))
-  (match-define (ivl x-min x-max) x-ivl)
-  (match-define (ivl y-min y-max) y-ivl)
-  (match-define (ivl z-min z-max) z-ivl)
-  (cond
-    [(and z-min z-max)
-     (define num (animated-samples samples))
-     (define sample (f (vector x-ivl y-ivl) (vector num num)))
-     ;; can't use the actual z ticks because some or all could be collapsed
-     (match-define (list (tick #{zs : (Listof Real)}
-                               #{_ : (Listof Boolean)}
-                               #{labels : (Listof String)})
-                         ...)
-       (contour-ticks (plot-z-ticks) z-min z-max levels #f))
-     
-     (let* ([colors  (generate-list colors zs)]
-            [widths  (generate-list widths zs)]
-            [styles  (generate-list styles zs)]
-            [alphas  (generate-list alphas zs)])
-       (for ([z  (in-list zs)]
-             [color  (in-cycle* (in-list colors))]
-             [width : Nonnegative-Real  (in-cycle* (in-list widths))]
-             [style  (in-cycle* (in-list styles))]
-             [alpha : Nonnegative-Real  (in-cycle* (in-list alphas))])
-         (send area put-alpha alpha)
-         (send area put-pen color width style)
-         (for-2d-sample
-          (xa xb ya yb z1 z2 z3 z4) sample
-          (for ([line  (in-list (heights->lines xa xb ya yb z z1 z2 z3 z4))])
-            (match-define (list v1 v2) line)
-            (send area put-line v1 v2))))
-       
-       (cond [label  (line-legend-entries label zs labels colors widths styles)]
-             [else   empty]))]
-    [else  empty]))
+(: make-contours3d-label-and-render (-> 2D-Sampler Contour-Levels Positive-Integer
+                                        (Plot-Colors (Listof Real))
+                                        (Pen-Widths (Listof Real))
+                                        (Plot-Pen-Styles (Listof Real))
+                                        (Alphas (Listof Real))
+                                        (U String pict #f)
+                                        (Values (U #f (-> Rect (Treeof legend-entry)))
+                                                3D-Render-Proc)))
+(define (make-contours3d-label-and-render f levels samples colors widths styles alphas label)
+  (define last-rect   : (U #f Rect)     #f)
+  (define last-zs     : (Listof Real)   empty)
+  (define last-sample : 2d-sample       (2d-sample '() '() #() #f #f))
+  (define last-labels : (Listof String) empty)
+  (define (update! [rect   : Rect]
+                   [sample : 2d-sample       (2d-sample '() '() #() #f #f)]
+                   [zs     : (Listof Real)   empty]
+                   [labels : (Listof String) empty])
+    (set! last-rect   rect)
+    (set! last-sample sample)
+    (set! last-zs     zs)
+    (set! last-labels labels))
+  
+  (define (calculate-zs/labels [rect : Rect]) : (Values 2d-sample (Listof Real) (Listof String))
+    (unless (equal? rect last-rect)
+      (match-define (vector x-ivl y-ivl z-ivl) rect)
+      (match-define (ivl x-min x-max) x-ivl)
+      (match-define (ivl y-min y-max) y-ivl)
+      (match-define (ivl z-min z-max) z-ivl)
+      (cond
+        [(and z-min z-max)
+         (define num (animated-samples samples))
+         (define sample (f (vector x-ivl y-ivl) (vector num num)))
+         ;; can't use the actual z ticks because some or all could be collapsed
+         (match-define (list (tick #{zs : (Listof Real)}
+                                   #{_ : (Listof Boolean)}
+                                   #{labels : (Listof String)})
+                             ...)
+           (contour-ticks (plot-z-ticks) z-min z-max levels #f))
+         (update! rect sample zs labels)]
+        [else (update! rect)]))
+    (values last-sample last-zs last-labels))
+
+  (define label-proc
+    (and label
+         (λ ([rect : Rect])
+           (define-values (_ zs labels) (calculate-zs/labels rect))
+           (cond
+             [(empty? zs) empty]
+             [else
+              (let* ([colors  (generate-list colors zs)]
+                     [widths  (generate-list widths zs)]
+                     [styles  (generate-list styles zs)])
+                (line-legend-entries label zs labels colors widths styles))]))))
+
+  (: render-proc 3D-Render-Proc)
+  (define (render-proc area)
+    (define-values (sample zs _) (calculate-zs/labels (send area get-bounds-rect)))
+    (match-define (vector x-ivl y-ivl z-ivl) (send area get-bounds-rect))
+    (match-define (ivl x-min x-max) x-ivl)
+    (match-define (ivl y-min y-max) y-ivl)
+    (match-define (ivl z-min z-max) z-ivl)
+    (unless (empty? zs)
+      (let* ([colors  (generate-list colors zs)]
+             [widths  (generate-list widths zs)]
+             [styles  (generate-list styles zs)]
+             [alphas  (generate-list alphas zs)])
+        (for ([z  (in-list zs)]
+              [color  (in-cycle* (in-list colors))]
+              [width : Nonnegative-Real  (in-cycle* (in-list widths))]
+              [style  (in-cycle* (in-list styles))]
+              [alpha : Nonnegative-Real  (in-cycle* (in-list alphas))])
+          (send area put-alpha alpha)
+          (send area put-pen color width style)
+          (for-2d-sample
+           (xa xb ya yb z1 z2 z3 z4) sample
+           (for ([line  (in-list (heights->lines xa xb ya yb z z1 z2 z3 z4))])
+             (match-define (list v1 v2) line)
+             (send area put-line v1 v2)))))))
+
+  (values label-proc render-proc))
 
 (:: contours3d
     (->* [(-> Real Real Real)]
@@ -165,103 +200,147 @@
      (define y-ivl (ivl y-min y-max))
      (define z-ivl (ivl z-min z-max))
      (define g (2d-function->sampler f (vector x-ivl y-ivl)))
+     (define-values (label-proc render-proc)
+       (make-contours3d-label-and-render g levels samples colors widths styles alphas label))
      (renderer3d (vector x-ivl y-ivl z-ivl)
                  (surface3d-bounds-fun g samples)
                  default-ticks-fun
-                 (contours3d-render-proc g levels samples colors widths styles alphas label))]))
+                 label-proc render-proc)]))
 
 ;; ===================================================================================================
 ;; Contour intervals in 3D (using marching squares)
 
-(: contour-intervals3d-render-proc (-> 2D-Sampler Contour-Levels Positive-Integer
-                                       (Plot-Colors (Listof ivl))
-                                       (Plot-Brush-Styles (Listof ivl))
-                                       (Plot-Colors (Listof ivl))
-                                       (Pen-Widths (Listof ivl))
-                                       (Plot-Pen-Styles (Listof ivl))
-                                       (Plot-Colors (Listof Real))
-                                       (Pen-Widths (Listof Real))
-                                       (Plot-Pen-Styles (Listof Real))
-                                       (Alphas (Listof ivl))
-                                       (U String pict #f)
-                                       3D-Render-Proc))
-(define ((contour-intervals3d-render-proc
+(: make-contour-intervals3d-label-and-renderer
+   (-> 2D-Sampler Contour-Levels Positive-Integer
+       (Plot-Colors (Listof ivl))
+       (Plot-Brush-Styles (Listof ivl))
+       (Plot-Colors (Listof ivl))
+       (Pen-Widths (Listof ivl))
+       (Plot-Pen-Styles (Listof ivl))
+       (Plot-Colors (Listof Real))
+       (Pen-Widths (Listof Real))
+       (Plot-Pen-Styles (Listof Real))
+       (Alphas (Listof ivl))
+       (U String pict #f)
+       (Values (U #f (-> Rect (Treeof legend-entry)))
+               3D-Render-Proc)))
+(define (make-contour-intervals3d-label-and-renderer
           f levels samples colors styles line-colors line-widths line-styles
           contour-colors contour-widths contour-styles alphas label)
-         area)
-  (match-define (vector x-ivl y-ivl z-ivl) (send area get-bounds-rect))
-  (match-define (ivl x-min x-max) x-ivl)
-  (match-define (ivl y-min y-max) y-ivl)
-  (match-define (ivl z-min z-max) z-ivl)
-  (cond
-    [(and z-min z-max)
-     (define num (animated-samples samples))
-     (define sample (f (vector x-ivl y-ivl) (vector num num)))
-     ;; can't use the actual z ticks because some or all could be collapsed
-     (match-define (list (tick #{zs : (Listof Real)}
-                               #{_ : (Listof Boolean)}
-                               #{labels : (Listof String)})
-                         ...)
-       (contour-ticks (plot-z-ticks) z-min z-max levels #t))
+  (define last-rect   : (U #f Rect)     #f)
+  (define last-zs     : (Listof Real)   empty)
+  (define last-zivls  : (Listof ivl)    empty)
+  (define last-sample : 2d-sample       (2d-sample '() '() #() #f #f))
+  (define last-labels : (Listof String) empty)
+  (define (update! [rect   : Rect]
+                   [sample : 2d-sample       (2d-sample '() '() #() #f #f)]
+                   [zivls  : (Listof ivl)    empty]
+                   [zs     : (Listof Real)   empty]
+                   [labels : (Listof String) empty])
+    (set! last-rect   rect)
+    (set! last-sample sample)
+    (set! last-zivls  zivls)
+    (set! last-zs     zs)
+    (set! last-labels labels))
+  
+  (define (calculate-zivls/labels [rect : Rect]) : (Values 2d-sample (Listof ivl) (Listof Real) (Listof String))
+    (unless (equal? rect last-rect)
+      (match-define (vector x-ivl y-ivl z-ivl) rect)
+      (match-define (ivl x-min x-max) x-ivl)
+      (match-define (ivl y-min y-max) y-ivl)
+      (match-define (ivl z-min z-max) z-ivl)
+      (cond
+        [(and z-min z-max)
+         (define num (animated-samples samples))
+         (define sample (f (vector x-ivl y-ivl) (vector num num)))
+         ;; can't use the actual z ticks because some or all could be collapsed
+         (match-define (list (tick #{zs : (Listof Real)}
+                                   #{_ : (Listof Boolean)}
+                                   #{labels : (Listof String)})
+                             ...)
+           (contour-ticks (plot-z-ticks) z-min z-max levels #t))
      
-     (define-values (z-ivls ivl-labels)
-       (for/lists ([z-ivls : (Listof ivl)]
-                   [ivl-labels : (Listof String)]
-                   ) ([za  (in-list zs)]
-                      [zb  (in-list (rest zs))]
-                      [la  (in-list labels)]
-                      [lb  (in-list (rest labels))])
-         (values (ivl za zb) (format "[~a,~a]" la lb))))
+         (define-values (z-ivls ivl-labels)
+           (for/lists ([z-ivls : (Listof ivl)]
+                       [ivl-labels : (Listof String)]
+                       ) ([za  (in-list zs)]
+                          [zb  (in-list (rest zs))]
+                          [la  (in-list labels)]
+                          [lb  (in-list (rest labels))])
+             (values (ivl za zb) (format "[~a,~a]" la lb))))
+          
+         (update! rect sample z-ivls zs ivl-labels)]
+        [else (update! rect)]))
+    (values last-sample last-zivls last-zs last-labels))
+
+  (define label-proc
+    (and label
+         (λ ([rect : Rect])
+           (define-values (_ z-ivls zs ivl-labels) (calculate-zivls/labels rect))
+           (let* ([colors  (generate-list colors z-ivls)]
+                  [styles  (generate-list styles z-ivls)]
+                  [line-colors  (generate-list line-colors z-ivls)]
+                  [line-widths  (generate-list line-widths z-ivls)]
+                  [line-styles  (generate-list line-styles z-ivls)])
+             (define n (- (length zs) 2))
+             (define contour-colors*
+               (append (list 0) (sequence-take (in-cycle* (generate-list contour-colors zs)) 0 n) (list 0)))
+             (define contour-widths*
+               (append (list 0) (sequence-take (in-cycle* (generate-list contour-widths zs)) 0 n) (list 0)))
+             (define contour-styles*
+               (append '(transparent) (sequence-take (in-cycle* (generate-list contour-styles zs)) 0 n)
+                       '(transparent)))
+       
+             (cond [label  (interval-legend-entries
+                            label z-ivls ivl-labels
+                            colors styles line-colors line-widths line-styles
+                            contour-colors* contour-widths* contour-styles*
+                            (rest contour-colors*) (rest contour-widths*) (rest contour-styles*))]
+                   [else  empty])))))
+  
+  (: render-proc 3D-Render-Proc)
+  (define (render-proc area)
+    (define-values (sample z-ivls zs _) (calculate-zivls/labels (send area get-bounds-rect)))
+    (unless (empty? zs)
+       
      
-     (let* ([colors  (generate-list colors z-ivls)]
-            [styles  (generate-list styles z-ivls)]
-            [alphas  (generate-list alphas z-ivls)]
-            [line-colors  (generate-list line-colors z-ivls)]
-            [line-widths  (generate-list line-widths z-ivls)]
-            [line-styles  (generate-list line-styles z-ivls)])
-       (for ([za  (in-list zs)]
-             [zb  (in-list (rest zs))]
-             [color  (in-cycle* (in-list colors))]
-             [style  (in-cycle* (in-list styles))]
-             [alpha : Nonnegative-Real  (in-cycle* (in-list alphas))]
-             [line-color  (in-cycle* (in-list line-colors))]
-             [line-width : Nonnegative-Real  (in-cycle* (in-list line-widths))]
-             [line-style  (in-cycle* (in-list line-styles))])
-         (send area put-alpha alpha)
-         (send area put-pen line-color line-width line-style)
-         (send area put-brush color style)
-         (for-2d-sample
-          (xa xb ya yb z1 z2 z3 z4) sample
-          (for ([vs  (in-list (heights->polys xa xb ya yb za zb z1 z2 z3 z4))])
-            (define ls
-              (for/list : (Listof Boolean) ([v1  (in-list (cons (last vs) vs))]
-                                            [v2  (in-list vs)])
-                (define z1 (vector-ref v1 2))
-                (define z2 (vector-ref v2 2))
-                (not (or (and (= z1 za) (= z2 za))
-                         (and (= z1 zb) (= z2 zb))))))
-            (send area put-polygon vs 'both ls))))
+       (let* ([colors  (generate-list colors z-ivls)]
+              [styles  (generate-list styles z-ivls)]
+              [alphas  (generate-list alphas z-ivls)]
+              [line-colors  (generate-list line-colors z-ivls)]
+              [line-widths  (generate-list line-widths z-ivls)]
+              [line-styles  (generate-list line-styles z-ivls)])
+         (for ([za  (in-list zs)]
+               [zb  (in-list (rest zs))]
+               [color  (in-cycle* (in-list colors))]
+               [style  (in-cycle* (in-list styles))]
+               [alpha : Nonnegative-Real  (in-cycle* (in-list alphas))]
+               [line-color  (in-cycle* (in-list line-colors))]
+               [line-width : Nonnegative-Real  (in-cycle* (in-list line-widths))]
+               [line-style  (in-cycle* (in-list line-styles))])
+           (send area put-alpha alpha)
+           (send area put-pen line-color line-width line-style)
+           (send area put-brush color style)
+           (for-2d-sample
+            (xa xb ya yb z1 z2 z3 z4) sample
+            (for ([vs  (in-list (heights->polys xa xb ya yb za zb z1 z2 z3 z4))])
+              (define ls
+                (for/list : (Listof Boolean) ([v1  (in-list (cons (last vs) vs))]
+                                              [v2  (in-list vs)])
+                  (define z1 (vector-ref v1 2))
+                  (define z2 (vector-ref v2 2))
+                  (not (or (and (= z1 za) (= z2 za))
+                           (and (= z1 zb) (= z2 zb))))))
+              (send area put-polygon vs 'both ls))))
+
+         (define-values (_ render-proc)
+           (make-contours3d-label-and-render f levels samples contour-colors contour-widths contour-styles
+                                             alphas #f))
+         (render-proc area)
        
-       ((contours3d-render-proc f levels samples contour-colors contour-widths contour-styles
-                                alphas #f)
-        area)
-       
-       (define n (- (length zs) 2))
-       (define contour-colors*
-         (append (list 0) (sequence-take (in-cycle* (generate-list contour-colors zs)) 0 n) (list 0)))
-       (define contour-widths*
-         (append (list 0) (sequence-take (in-cycle* (generate-list contour-widths zs)) 0 n) (list 0)))
-       (define contour-styles*
-         (append '(transparent) (sequence-take (in-cycle* (generate-list contour-styles zs)) 0 n)
-                 '(transparent)))
-       
-       (cond [label  (interval-legend-entries
-                      label z-ivls ivl-labels
-                      colors styles line-colors line-widths line-styles
-                      contour-colors* contour-widths* contour-styles*
-                      (rest contour-colors*) (rest contour-widths*) (rest contour-styles*))]
-             [else  empty]))]
-    [else  empty]))
+         )))
+
+  (values label-proc render-proc))
 
 (:: contour-intervals3d
     (->* [(-> Real Real Real)]
@@ -312,10 +391,12 @@
      (define y-ivl (ivl y-min y-max))
      (define z-ivl (ivl z-min z-max))
      (define g (2d-function->sampler f (vector x-ivl y-ivl)))
+     (define-values (label-proc render-proc)
+       (make-contour-intervals3d-label-and-renderer g levels samples colors styles
+                                                    line-colors line-widths line-styles
+                                                    contour-colors contour-widths contour-styles
+                                                    alphas label))
      (renderer3d (vector x-ivl y-ivl z-ivl)
                  (surface3d-bounds-fun g samples)
                  default-ticks-fun
-                 (contour-intervals3d-render-proc g levels samples colors styles
-                                                  line-colors line-widths line-styles
-                                                  contour-colors contour-widths contour-styles
-                                                  alphas label))]))
+                 label-proc render-proc)]))

--- a/plot-lib/plot/private/plot3d/decoration.rkt
+++ b/plot-lib/plot/private/plot3d/decoration.rkt
@@ -46,9 +46,7 @@
     ; point
     (send area put-pen point-color point-line-width 'solid)
     (send area put-brush point-fill-color 'solid)
-    (send area put-glyphs (list v) point-sym point-size plot3d-front-layer))
-  
-  empty)
+    (send area put-glyphs (list v) point-sym point-size plot3d-front-layer)))
 
 (:: point-label3d
     (->* [(Sequenceof Real)]
@@ -89,7 +87,7 @@
     [else
      (let ([v  (sequence-head-vector 'point-label3d v 3)])
        (match-define (vector x y z) v)
-       (renderer3d (vector (ivl x x) (ivl y y) (ivl z z)) #f #f
+       (renderer3d (vector (ivl x x) (ivl y y) (ivl z z)) #f #f #f
                    (label3d-render-proc
                     label v color size face family anchor angle
                     point-color (cond [(eq? point-fill-color 'auto)  (->pen-color point-color)]

--- a/plot-lib/plot/private/plot3d/line.rkt
+++ b/plot-lib/plot/private/plot3d/line.rkt
@@ -13,15 +13,11 @@
 (: lines3d-render-proc (-> (-> (Listof (Vectorof Real)))
                            Plot-Color Nonnegative-Real Plot-Pen-Style
                            Nonnegative-Real
-                           (U String pict #f)
                            3D-Render-Proc))
-(define ((lines3d-render-proc vs-fun color width style alpha label) area)
+(define ((lines3d-render-proc vs-fun color width style alpha) area)
   (send area put-alpha alpha)
   (send area put-pen color width style)
-  (send area put-lines (vs-fun))
-  
-  (cond [label  (line-legend-entry label color width style)]
-        [else  empty]))
+  (send area put-lines (vs-fun)))
 
 (: lines3d-renderer (-> (-> (Listof (Vectorof Real)))
                         (U #f Real) (U #f Real) (U #f Real) (U #f Real) (U #f Real) (U #f Real)
@@ -32,7 +28,7 @@
 (define (lines3d-renderer
          vs-thnk x-min x-max y-min y-max z-min z-max color width style alpha label)
   (define rvs (filter vrational? (vs-thnk)))
-  (cond [(empty? rvs)  (renderer3d #f #f #f #f)]
+  (cond [(empty? rvs)  empty-renderer3d]
         [else
          (match-define (list (vector #{rxs : (Listof Real)}
                                      #{rys : (Listof Real)}
@@ -47,7 +43,8 @@
                [z-max  (if z-max z-max (apply max* rzs))])
            (renderer3d (vector (ivl x-min x-max) (ivl y-min y-max) (ivl z-min z-max)) #f
                        default-ticks-fun
-                       (lines3d-render-proc vs-thnk color width style alpha label)))]))
+                       (and label (λ (_) (line-legend-entry label color width style)))
+                       (lines3d-render-proc vs-thnk color width style alpha)))]))
 
 (:: lines3d
     (->* [(Sequenceof (Sequenceof Real))]

--- a/plot-lib/plot/private/plot3d/param-surf.rkt
+++ b/plot-lib/plot/private/plot3d/param-surf.rkt
@@ -13,18 +13,14 @@
                              Plot-Color Plot-Brush-Style
                              Plot-Color Nonnegative-Real Plot-Pen-Style
                              Nonnegative-Real
-                             (U String pict #f)
                              3D-Render-Proc))
-(define ((polygons3d-render-proc vs-fun color style line-color line-width line-style alpha label)
+(define ((polygons3d-render-proc vs-fun color style line-color line-width line-style alpha)
          area)
   (send area put-alpha alpha)
   (send area put-brush color style)
   (send area put-pen line-color line-width line-style)
   (for ([v (in-list (vs-fun))])
-    (send area put-polygon v))
-  
-  (cond [label  (rectangle-legend-entry label color style line-color line-width line-style)]
-        [else   empty]))
+    (send area put-polygon v)))
 
 (: polygons3d-renderer (-> (-> (Listof (Listof (Vectorof Real))))
                            (U #f Real) (U #f Real) (U #f Real) (U #f Real) (U #f Real) (U #f Real)
@@ -37,7 +33,7 @@
                              color style line-color line-width line-style alpha label)
   (define rvs (filter vrational? (apply append (vs-thnk))))
   (cond
-    [(empty? rvs) (renderer3d #f #f #f #f)]
+    [(empty? rvs) empty-renderer3d]
     [else
      (match-define (list (vector #{rxs : (Listof Real)}
                                  #{rys : (Listof Real)}
@@ -53,8 +49,9 @@
        (renderer3d (vector (ivl x-min x-max)(ivl y-min y-max)(ivl z-min z-max))
                    #f ;surface3d-bounds-fun
                    default-ticks-fun
+                   (and label (λ (_) (rectangle-legend-entry label color style line-color line-width line-style)))
                    (polygons3d-render-proc vs-thnk
-                                           color style line-color line-width line-style alpha label)))]))
+                                           color style line-color line-width line-style alpha)))]))
 (:: polygons3d
     (->* [(Sequenceof (Sequenceof (Sequenceof Real)))]
          [#:x-min (U #f Real) #:x-max (U #f Real)

--- a/plot-lib/plot/private/plot3d/rectangle.rkt
+++ b/plot-lib/plot/private/plot3d/rectangle.rkt
@@ -15,18 +15,14 @@
                                 Plot-Color Plot-Brush-Style
                                 Plot-Color Nonnegative-Real Plot-Pen-Style
                                 Nonnegative-Real
-                                (U String pict #f)
                                 3D-Render-Proc))
-(define ((rectangles3d-render-proc rects color style line-color line-width line-style alpha label)
+(define ((rectangles3d-render-proc rects color style line-color line-width line-style alpha)
          area)
   (send area put-pen line-color line-width line-style)
   (send area put-brush color style)
   (send area put-alpha alpha)
   (for ([rect  (in-list rects)])
-    (send area put-rect rect))
-  
-  (cond [label  (rectangle-legend-entry label color style line-color line-width line-style)]
-        [else  empty]))
+    (send area put-rect rect)))
 
 (:: rectangles3d
     (->* [(Sequenceof (Sequenceof ivl))]
@@ -76,7 +72,7 @@
        (define rys (filter rational? (append y1s y2s)))
        (define rzs (filter rational? (append z1s z2s)))
        (cond
-         [(or (empty? rxs) (empty? rys) (empty? rzs))  (renderer3d #f #f #f #f)]
+         [(or (empty? rxs) (empty? rys) (empty? rzs))  empty-renderer3d]
          [else
           (let ([x-min  (if x-min x-min (apply min* rxs))]
                 [x-max  (if x-max x-max (apply max* rxs))]
@@ -86,8 +82,10 @@
                 [z-max  (if z-max z-max (apply max* rzs))])
             (renderer3d (vector (ivl x-min x-max) (ivl y-min y-max) (ivl z-min z-max)) #f
                         default-ticks-fun
+                        (and label (λ (_) (rectangle-legend-entry
+                                           label color style line-color line-width line-style)))
                         (rectangles3d-render-proc rects color style line-color line-width line-style
-                                                  alpha label)))]))]))
+                                                  alpha)))]))]))
 
 ;; ===================================================================================================
 ;; Discrete histograms
@@ -185,7 +183,7 @@
                                      (list z1 z2)]
                           [else  (list z)])))))
        (cond
-         [(empty? rzs)  (renderer3d #f #f #f #f)]
+         [(empty? rzs)  empty-renderer3d]
          [else
           (define c1s (remove-duplicates cat1s))
           (define c2s (remove-duplicates cat2s))
@@ -234,8 +232,10 @@
              (vector (ivl x-min x-max) (ivl y-min y-max) (ivl z-min z-max)) #f
              (discrete-histogram3d-ticks-fun c1s c2s tick-xs tick-ys
                                              add-x-ticks? add-y-ticks? x-far-ticks? y-far-ticks?)
+             (and label (λ (_) (rectangle-legend-entry
+                                           label color style line-color line-width line-style)))
              (rectangles3d-render-proc rects color style line-color line-width line-style
-                                       alpha label)))]))]))
+                                       alpha)))]))]))
 
 (:: stacked-histogram3d
     (->* [(Sequenceof (U (Vector Any Any (Sequenceof Real))

--- a/plot-lib/plot/private/plot3d/renderer.rkt
+++ b/plot-lib/plot/private/plot3d/renderer.rkt
@@ -3,10 +3,15 @@
 (require "../common/plot-element.rkt"
          "../common/types.rkt"
          "../common/type-doc.rkt"
+         "../common/math.rkt"
          "plot-area.rkt")
 
 (provide (all-defined-out))
 
-(deftype 3D-Render-Proc (-> (Instance 3D-Plot-Area%) (Treeof legend-entry)))
+(deftype 3D-Render-Proc (-> (Instance 3D-Plot-Area%) Void))
 
-(struct renderer3d plot-element ([render-proc : (U #f 3D-Render-Proc)]) #:transparent)
+(struct renderer3d plot-element ([label : (U #f (-> Rect (Treeof legend-entry)))]
+                                 [render-proc : (U #f 3D-Render-Proc)])
+  #:transparent)
+
+(define empty-renderer3d (renderer3d #f #f #f #f #f))

--- a/plot-lib/plot/private/plot3d/surface.rkt
+++ b/plot-lib/plot/private/plot3d/surface.rkt
@@ -15,9 +15,8 @@
                              Plot-Color Plot-Brush-Style
                              Plot-Color Nonnegative-Real Plot-Pen-Style
                              Nonnegative-Real
-                             (U String pict #f)
                              3D-Render-Proc))
-(define ((surface3d-render-proc f samples color style line-color line-width line-style alpha label)
+(define ((surface3d-render-proc f samples color style line-color line-width line-style alpha)
          area)
   (match-define (vector x-ivl y-ivl z-ivl) (send area get-bounds-rect))
   (define num (animated-samples samples))
@@ -30,9 +29,7 @@
    (xa xb ya yb z1 z2 z3 z4) sample
    (define vs (list (vector xa ya z1) (vector xb ya z2) (vector xb yb z3) (vector xa yb z4)))
    (send area put-polygon vs))
-  
-  (cond [label  (rectangle-legend-entry label color style line-color line-width line-style)]
-        [else   empty]))
+  (void))
 
 (:: surface3d
     (->* [(-> Real Real Real)]
@@ -75,5 +72,6 @@
      (renderer3d (vector x-ivl y-ivl z-ivl)
                  (surface3d-bounds-fun g samples)
                  default-ticks-fun
+                 (and label (λ (_) (rectangle-legend-entry label color style line-color line-width line-style)))
                  (surface3d-render-proc g samples color style
-                                        line-color line-width line-style alpha label))]))
+                                        line-color line-width line-style alpha))]))

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -313,4 +313,5 @@
  (struct-out plot-element)
  (struct-out nonrenderer)
  (struct-out renderer2d)
+ empty-renderer2d
  (struct-out renderer3d))

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -314,4 +314,5 @@
  (struct-out nonrenderer)
  (struct-out renderer2d)
  empty-renderer2d
- (struct-out renderer3d))
+ (struct-out renderer3d)
+ empty-renderer3d)


### PR DESCRIPTION
PR to begin solving #49 
This is a first attempt to separate legend and function calculation (2D)

The nastiest change is for contour and contour-intervals. The legend(label) and function calculation are quite interwoven for these procedures.

With this change it should be possible to get the legend entries at any point, provided the bounds for the plot area are known (necessary for contour/-intervals). 

For contour/-intervals it uses internal state to prevent calculating the function twice.