### PR TITLE
[Legend pt3] Make legend available to area at start

### DIFF
--- a/plot-compat/plot/private/compat.rkt
+++ b/plot-compat/plot/private/compat.rkt
@@ -165,7 +165,7 @@
     (define bm (make-bitmap (ceiling width) (ceiling height)))
     (define dc (make-object bitmap-dc% bm))
     (define area (make-object 2d-plot-area%
-                   bounds-rect x-ticks x-ticks y-ticks y-ticks dc 0 0 width height))
+                   bounds-rect x-ticks x-ticks y-ticks y-ticks '() dc 0 0 width height))
     
     (define data+axes (mix x-axis-data y-axis-data data))
     
@@ -214,7 +214,7 @@
     (define bm (make-bitmap (ceiling width) (ceiling height)))
     (define dc (make-object bitmap-dc% bm))
     (define area (make-object 3d-plot-area%
-                   bounds-rect x-ticks x-ticks y-ticks y-ticks z-ticks z-ticks dc 0 0 width height))
+                   bounds-rect x-ticks x-ticks y-ticks y-ticks z-ticks z-ticks '() dc 0 0 width height))
     
     (send area start-plot)
     (send area start-renderer bounds-rect)

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -112,7 +112,7 @@
         (define dc (make-object bitmap-dc% bm))
         (define-values (x-ticks x-far-ticks y-ticks y-far-ticks)
           (get-ticks renderer-list bounds-rect))
-        (define legend (get-legend-list renderer-list bounds-rect))
+        (define legend (get-legend-entry-list renderer-list bounds-rect))
         (define new-area
           (make-object 2d-plot-area%
                        bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks legend

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -66,7 +66,7 @@
           #:title (U String pict #f)
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          (Instance Snip%)))
 (define (plot-snip renderer-tree
                    #:x-min [x-min #f] #:x-max [x-max #f]
@@ -112,9 +112,10 @@
         (define dc (make-object bitmap-dc% bm))
         (define-values (x-ticks x-far-ticks y-ticks y-far-ticks)
           (get-ticks renderer-list bounds-rect))
+        (define legend (get-legend-list renderer-list bounds-rect))
         (define new-area
           (make-object 2d-plot-area%
-                       bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks
+                       bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks legend
                        dc 0 0 width height))
         (set! area new-area)
         (plot-area new-area renderer-list))
@@ -136,7 +137,7 @@
           #:title (U String pict #f)
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          (Instance Frame%)))
 (define (plot-frame renderer-tree
                     #:x-min [x-min #f] #:x-max [x-max #f]

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -89,7 +89,7 @@
     [(and title (not (or (string? title) (pict? title)))) (fail/kw "#f, string or pict" '#:title title)]
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "anchor/c" '#:legend-anchor legend-anchor)])
+    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
 
   (parameterize ([plot-title          title]
                  [plot-x-label        x-label]
@@ -160,7 +160,7 @@
     [(and title (not (or (string? title) (pict? title)))) (fail/kw "#f, string or pict" '#:title title)]
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "anchor/c" '#:legend-anchor legend-anchor)])
+    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
 
   ;; make-snip will be called in a separate thread, make sure the
   ;; parameters have the correct values in that thread as well.
@@ -186,7 +186,7 @@
           #:title (U String pict #f)
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
-          #:legend-anchor Anchor
+          #:legend-anchor Legend-Anchor
           #:out-file (U Path-String Output-Port #f)
           #:out-kind (U 'auto Image-File-Format)
           #:fgcolor Plot-Color
@@ -226,7 +226,7 @@
     [(and title (not (or (string? title) (pict? title)))) (fail/kw "#f, string or pict" '#:title title)]
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "anchor/c" '#:legend-anchor legend-anchor)]
+    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)]
     [(and out-kind (not (plot-file-format/c out-kind))) (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
     [(not (plot-file-format/c out-kind)) (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
     [(and fgcolor (not (plot-color/c fgcolor))) (fail/kw "plot-color/c" '#:fgcolor fgcolor)]

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -50,7 +50,7 @@
                 plot)
 
 (require/typed plot/utils
-  (anchor/c (-> Any Boolean))
+  (legend-anchor/c (-> Any Boolean))
   (plot-color/c (-> Any Boolean))
   (plot-file-format/c (-> Any Boolean)))
 
@@ -89,7 +89,7 @@
     [(and title (not (or (string? title) (pict? title)))) (fail/kw "#f, string or pict" '#:title title)]
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
+    [(not (legend-anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
 
   (parameterize ([plot-title          title]
                  [plot-x-label        x-label]
@@ -160,7 +160,7 @@
     [(and title (not (or (string? title) (pict? title)))) (fail/kw "#f, string or pict" '#:title title)]
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
+    [(not (legend-anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
 
   ;; make-snip will be called in a separate thread, make sure the
   ;; parameters have the correct values in that thread as well.
@@ -226,7 +226,7 @@
     [(and title (not (or (string? title) (pict? title)))) (fail/kw "#f, string or pict" '#:title title)]
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)]
+    [(not (legend-anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)]
     [(and out-kind (not (plot-file-format/c out-kind))) (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
     [(not (plot-file-format/c out-kind)) (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
     [(and fgcolor (not (plot-color/c fgcolor))) (fail/kw "plot-color/c" '#:fgcolor fgcolor)]

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -76,7 +76,7 @@
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
     [(and z-label (not (or (string? z-label) (pict? z-label)))) (fail/kw "#f, string or pict" '#:y-label z-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "anchor/c" '#:legend-anchor legend-anchor)])
+    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
 
   (parameterize ([plot-title          title]
                  [plot-x-label        x-label]
@@ -177,7 +177,7 @@
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
     [(and z-label (not (or (string? z-label) (pict? z-label)))) (fail/kw "#f, string or pict" '#:y-label z-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "anchor/c" '#:legend-anchor legend-anchor)])
+    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
 
   ;; make-snip will be called in a separate thread, make sure the
   ;; parameters have the correct values in that thread as well.
@@ -208,7 +208,7 @@
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
           #:z-label (U String pict #f)
-          #:legend-anchor Anchor
+          #:legend-anchor Legend-Anchor
           #:out-file (U Path-String Output-Port #f)
           #:out-kind (U 'auto Image-File-Format)
           #:fgcolor Plot-Color
@@ -264,7 +264,7 @@
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
     [(and z-label (not (or (string? z-label) (pict? z-label)))) (fail/kw "#f, string or pict" '#:y-label z-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "anchor/c" '#:legend-anchor legend-anchor)]
+    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)]
     [(and out-kind (not (plot-file-format/c out-kind))) (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
     [(not (plot-file-format/c out-kind)) (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
     [(and fgcolor (not (plot-color/c fgcolor))) (fail/kw "plot-color/c" '#:fgcolor fgcolor)]

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -25,7 +25,7 @@
                 plot3d)
 
 (require/typed plot/utils
-  (anchor/c (-> Any Boolean))
+  (legend-anchor/c (-> Any Boolean))
   (plot-color/c (-> Any Boolean))
   (plot-file-format/c (-> Any Boolean)))
 
@@ -76,7 +76,7 @@
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
     [(and z-label (not (or (string? z-label) (pict? z-label)))) (fail/kw "#f, string or pict" '#:y-label z-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
+    [(not (legend-anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
 
   (parameterize ([plot-title          title]
                  [plot-x-label        x-label]
@@ -177,7 +177,7 @@
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
     [(and z-label (not (or (string? z-label) (pict? z-label)))) (fail/kw "#f, string or pict" '#:y-label z-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
+    [(not (legend-anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)])
 
   ;; make-snip will be called in a separate thread, make sure the
   ;; parameters have the correct values in that thread as well.
@@ -264,7 +264,7 @@
     [(and x-label (not (or (string? x-label) (pict? x-label)))) (fail/kw "#f, string or pict" '#:x-label x-label)]
     [(and y-label (not (or (string? y-label) (pict? y-label)))) (fail/kw "#f, string or pict" '#:y-label y-label)]
     [(and z-label (not (or (string? z-label) (pict? z-label)))) (fail/kw "#f, string or pict" '#:y-label z-label)]
-    [(not (anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)]
+    [(not (legend-anchor/c legend-anchor)) (fail/kw "legend-anchor/c" '#:legend-anchor legend-anchor)]
     [(and out-kind (not (plot-file-format/c out-kind))) (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
     [(not (plot-file-format/c out-kind)) (fail/kw "plot-file-format/c" '#:out-kind out-kind)]
     [(and fgcolor (not (plot-color/c fgcolor))) (fail/kw "plot-color/c" '#:fgcolor fgcolor)]

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -91,7 +91,7 @@
 
     (define render-tasks-hash ((inst make-hash Boolean render-tasks)))
     ;; For 3D legend can be calculated once since we don't change the bounding box
-    (define legend (get-legend-list renderer-list bounds-rect))
+    (define legend (get-legend-entry-list renderer-list bounds-rect))
 
     (: make-bm (-> Boolean Real Real Positive-Integer Positive-Integer (Instance Bitmap%)))
     (define (make-bm anim? angle altitude width height)

--- a/plot-lib/plot/private/common/contract.rkt
+++ b/plot-lib/plot/private/common/contract.rkt
@@ -34,6 +34,8 @@
 (define anchor/c (one-of/c 'top-left    'top    'top-right
                            'left        'center 'right
                            'bottom-left 'bottom 'bottom-right))
+(define legend-anchor/c (or/c #f anchor/c
+                              (list/c (one-of/c 'inside 'outside) anchor/c)))
 
 (define color/c (or/c (list/c real? real? real?)
                       string? symbol?

--- a/plot-lib/plot/private/common/parameter-groups.rkt
+++ b/plot-lib/plot/private/common/parameter-groups.rkt
@@ -100,7 +100,7 @@
       (U False Nonnegative-Real)
       (U False String)
       (U False Font-Family)
-      Anchor
+      Legend-Anchor
       Nonnegative-Real
       (List Boolean Boolean Boolean Boolean Boolean Boolean)
       (List Boolean Anchor Real (U Boolean 'auto) Anchor Real Boolean Anchor Real (U Boolean 'auto) Anchor Real)

--- a/plot-lib/plot/private/common/parameters.rkt
+++ b/plot-lib/plot/private/common/parameters.rkt
@@ -75,7 +75,7 @@
 (defparam plot-legend-font-size size (U Nonnegative-Real #f) #f)
 (defparam plot-legend-font-face face (U String #f) #f)
 (defparam plot-legend-font-family family (U Font-Family #f) #f)
-(defparam plot-legend-anchor anchor Anchor 'top-left)
+(defparam plot-legend-anchor anchor Legend-Anchor 'top-left)
 (defparam2 plot-legend-box-alpha alpha Real Nonnegative-Real 2/3 (unit-ivl 'plot-legend-box-alpha))
 (defparam plot-animating? Boolean #f)
 

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -17,6 +17,7 @@
      'left        'center 'right
      'bottom-left 'bottom 'bottom-right
      'auto))
+(define-predicate anchor? Anchor)
 
 (deftype Color
   (U (List Real Real Real)
@@ -92,6 +93,15 @@
 
 (struct legend-entry ([label : (U String pict)] [draw : Legend-Draw-Proc]) #:transparent)
 
+(deftype Legend-Anchor (U #f Anchor (List (U 'inside 'outside) Anchor)))
+(define (inside-anchor [a : Legend-Anchor])
+  (and a
+       (if (list? a)
+           (and (eq? (car a) 'inside) (cadr a))
+           a)))
+(define (outside-anchor [a : Legend-Anchor])
+  (and a (list? a) (eq? (car a) 'outside) (cadr a)))
+
 (define-type Plot-Device%
   (Class
    (init-field [dc (Instance DC<%>)]
@@ -133,5 +143,5 @@
    [draw-arrow-glyph (-> (Vectorof Real) Real Real Void)]
    [draw-glyphs (-> (Listof (Vectorof Real)) Point-Sym Nonnegative-Real Void)]
    [draw-pict (->* [pict (Vectorof Real)] (Anchor Real) Void)]
-   [calculate-legend-rect (-> (Listof legend-entry) Rect Rect)]
+   [calculate-legend-rect (-> (Listof legend-entry) Rect Anchor Rect)]
    [draw-legend (-> (Listof legend-entry) Rect Void)]))

--- a/plot-lib/plot/private/no-gui/plot2d-untyped.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d-untyped.rkt
@@ -26,7 +26,7 @@
          #:title (or/c string? pict? #f)
          #:x-label (or/c string? pict? #f)
          #:y-label (or/c string? pict? #f)
-         #:legend-anchor anchor/c]
+         #:legend-anchor legend-anchor/c]
         void?)]
    [untyped-plot-bitmap
     (->* [(treeof (or/c renderer2d? nonrenderer?))]
@@ -39,7 +39,7 @@
           #:width (or/c real? #f)
           #:x-label (or/c string? pict? #f)
           #:y-label (or/c string? pict? #f)
-          #:legend-anchor anchor/c]
+          #:legend-anchor legend-anchor/c]
          (is-a?/c bitmap%))]
     [untyped-plot-pict
      (->* [(treeof (or/c renderer2d? nonrenderer?))]
@@ -52,7 +52,7 @@
            #:height (or/c real? #f)
            #:width (or/c real? #f)
            #:y-label (or/c string? pict? #f)
-           #:legend-anchor anchor/c]
+           #:legend-anchor legend-anchor/c]
           pict?)]))
 
 (define untyped-plot/dc plot/dc)

--- a/plot-lib/plot/private/no-gui/plot2d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d-utils.rkt
@@ -70,10 +70,11 @@
   
   (for ([rend  (in-list renderer-list)])
     (match-define (renderer2d rend-bounds-rect _bf _tf label-proc render-proc) rend)
+    ;; next step could be moved into (when render-proc, but this generates different step files)
+    (send area start-renderer (if rend-bounds-rect
+                                  (rect-inexact->exact rend-bounds-rect)
+                                  (unknown-rect 2)))
     (when render-proc
-      (send area start-renderer (if rend-bounds-rect
-                                    (rect-inexact->exact rend-bounds-rect)
-                                    (unknown-rect 2)))
       (render-proc area)))
   
   (send area end-renderers)
@@ -103,9 +104,8 @@
      (flatten-legend-entries
       (for*/list : (Listof (Treeof legend-entry))
         ([rend  (in-list renderer-list)]
-         [rect (in-value (let ([r (plot-element-bounds-rect rend)])
-                           (or (and r (clip r)) outer-rect)))]
          [label-proc (in-value (renderer2d-label rend))]
          #:when label-proc)
-        (label-proc rect)))]
+        ;; clipping not necessary, levels are always calculated on the complete bounds-rect
+        (label-proc outer-rect)))]
     [else '()]))

--- a/plot-lib/plot/private/no-gui/plot2d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d-utils.rkt
@@ -86,21 +86,6 @@
 
   (cond
     [(and x-min x-max y-min y-max)
-
-     (: clip (-> Rect Rect))
-     (define (clip rect)
-       (match-define (vector (ivl rx-min rx-max) (ivl ry-min ry-max)) rect)
-       (define cx-min (if rx-min (max* x-min rx-min) x-min))
-       (define cx-max (if rx-max (min* x-max rx-max) x-max))
-       (define cy-min (if ry-min (max* y-min ry-min) y-min))
-       (define cy-max (if ry-max (min* y-max ry-max) y-max))
-       (let ([cx-min  (min* cx-min cx-max)]
-             [cx-max  (max* cx-min cx-max)]
-             [cy-min  (min* cy-min cy-max)]
-             [cy-max  (max* cy-min cy-max)])
-         (vector (ivl cx-min cx-max)
-                 (ivl cy-min cy-max))))
-
      (flatten-legend-entries
       (for*/list : (Listof (Treeof legend-entry))
         ([rend  (in-list renderer-list)]

--- a/plot-lib/plot/private/no-gui/plot2d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d-utils.rkt
@@ -12,7 +12,7 @@
          "utils.rkt"
          typed/racket/unsafe)
 
-(provide get-renderer-list get-bounds-rect get-ticks get-legend-list)
+(provide get-renderer-list get-bounds-rect get-ticks get-legend-entry-list)
 (unsafe-provide plot-area)
 
 (: get-renderer-list (-> Any (Listof renderer2d)))
@@ -80,8 +80,8 @@
   (send area end-renderers)
   (send area end-plot))
 
-(: get-legend-list (-> (Listof renderer2d) Rect (Listof legend-entry)))
-(define (get-legend-list renderer-list outer-rect)
+(: get-legend-entry-list (-> (Listof renderer2d) Rect (Listof legend-entry)))
+(define (get-legend-entry-list renderer-list outer-rect)
   (match-define (vector (ivl  x-min  x-max) (ivl  y-min  y-max)) outer-rect)
 
   (cond

--- a/plot-lib/plot/private/no-gui/plot2d.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d.rkt
@@ -35,7 +35,7 @@
           #:title (U String pict #f)
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          Void))
 (define (plot/dc renderer-tree dc x y width height
                  #:x-min [x-min #f] #:x-max [x-max #f]
@@ -60,13 +60,14 @@
      (define bounds-rect (get-bounds-rect renderer-list x-min x-max y-min y-max))
      (define-values (x-ticks x-far-ticks y-ticks y-far-ticks)
        (get-ticks renderer-list bounds-rect))
+     (define legend (get-legend-list renderer-list bounds-rect))
      
      (parameterize ([plot-title          title]
                     [plot-x-label        x-label]
                     [plot-y-label        y-label]
                     [plot-legend-anchor  legend-anchor])
        (define area (make-object 2d-plot-area%
-                      bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks dc x y width height))
+                      bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks legend dc x y width height))
        (plot-area area renderer-list))]))
 
 ;; ===================================================================================================
@@ -81,7 +82,7 @@
           #:title (U String pict #f)
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          (Instance Bitmap%)))
 (define (plot-bitmap renderer-tree
                      #:x-min [x-min #f] #:x-max [x-max #f]
@@ -111,7 +112,7 @@
           #:title (U String pict #f)
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          Pict))
 (define (plot-pict renderer-tree
                    #:x-min [x-min #f] #:x-max [x-max #f]
@@ -144,7 +145,7 @@
           #:title (U String pict #f)
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          Void))
 (define (plot-file renderer-tree output [kind 'auto]
                    #:x-min [x-min #f] #:x-max [x-max #f]

--- a/plot-lib/plot/private/no-gui/plot2d.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d.rkt
@@ -60,7 +60,7 @@
      (define bounds-rect (get-bounds-rect renderer-list x-min x-max y-min y-max))
      (define-values (x-ticks x-far-ticks y-ticks y-far-ticks)
        (get-ticks renderer-list bounds-rect))
-     (define legend (get-legend-list renderer-list bounds-rect))
+     (define legend (get-legend-entry-list renderer-list bounds-rect))
      
      (parameterize ([plot-title          title]
                     [plot-x-label        x-label]

--- a/plot-lib/plot/private/no-gui/plot3d-untyped.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d-untyped.rkt
@@ -32,7 +32,7 @@
          #:x-label (or/c string? pict? #f)
          #:y-label (or/c string? pict? #f)
          #:z-label (or/c string? pict? #f)
-         #:legend-anchor anchor/c]
+         #:legend-anchor legend-anchor/c]
         void?)]))
 
 (define-syntax untyped-plot3d/dc

--- a/plot-lib/plot/private/no-gui/plot3d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d-utils.rkt
@@ -96,25 +96,6 @@
 
   (cond
     [(and x-min x-max y-min y-max z-min z-max)
-
-    (: clip (-> Rect Rect))
-    (define (clip rect)
-      (match-define (vector (ivl rx-min rx-max) (ivl ry-min ry-max) (ivl rz-min rz-max)) rect)
-      (define cx-min (if rx-min (max* x-min rx-min) x-min))
-      (define cx-max (if rx-max (min* x-max rx-max) x-max))
-      (define cy-min (if ry-min (max* y-min ry-min) y-min))
-      (define cy-max (if ry-max (min* y-max ry-max) y-max))
-      (define cz-min (if rz-min (max* z-min rz-min) z-min))
-      (define cz-max (if rz-max (min* z-max rz-max) z-max))
-      (let ([cx-min  (min* cx-min cx-max)]
-            [cx-max  (max* cx-min cx-max)]
-            [cy-min  (min* cy-min cy-max)]
-            [cy-max  (max* cy-min cy-max)]
-            [cz-min  (min* cz-min cz-max)]
-            [cz-max  (max* cz-min cz-max)])
-        (vector (ivl cx-min cx-max)
-                (ivl cy-min cy-max)
-                (ivl cz-min cz-max))))
     (flatten-legend-entries
      (for*/list : (Listof (Treeof legend-entry))
        ([rend  (in-list renderer-list)]

--- a/plot-lib/plot/private/no-gui/plot3d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d-utils.rkt
@@ -12,7 +12,7 @@
          "utils.rkt"
          typed/racket/unsafe)
 
-(provide get-renderer-list get-bounds-rect get-ticks get-legend-list)
+(provide get-renderer-list get-bounds-rect get-ticks get-legend-entry-list)
 (unsafe-provide plot-area)
 
 (: get-renderer-list (-> Any (Listof renderer3d)))
@@ -90,8 +90,8 @@
   (send area end-renderers)
   (send area end-plot))
 
-(: get-legend-list (-> (Listof renderer3d) Rect (Listof legend-entry)))
-(define (get-legend-list renderer-list outer-rect)
+(: get-legend-entry-list (-> (Listof renderer3d) Rect (Listof legend-entry)))
+(define (get-legend-entry-list renderer-list outer-rect)
   (match-define (vector (ivl  x-min  x-max) (ivl  y-min  y-max) (ivl  z-min  z-max)) outer-rect)
 
   (cond

--- a/plot-lib/plot/private/no-gui/plot3d-utils.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d-utils.rkt
@@ -80,10 +80,11 @@
   
   (for ([rend  (in-list renderer-list)])
     (match-define (renderer3d rend-bounds-rect _bf _tf label-proc render-proc) rend)
+    ;; next step could be moved into (when render-proc, but this generates different step files)
+    (send area start-renderer (if rend-bounds-rect
+                                  (rect-inexact->exact rend-bounds-rect)
+                                  (unknown-rect 3)))
     (when render-proc
-      (send area start-renderer (if rend-bounds-rect
-                                    (rect-inexact->exact rend-bounds-rect)
-                                    (unknown-rect 3)))
       (render-proc area)))
   
   (send area end-renderers)
@@ -117,9 +118,7 @@
     (flatten-legend-entries
      (for*/list : (Listof (Treeof legend-entry))
        ([rend  (in-list renderer-list)]
-        [rect (in-value (let ([r (plot-element-bounds-rect rend)])
-                          (or (and r (clip r)) outer-rect)))]
         [label-proc (in-value (renderer3d-label rend))]
         #:when label-proc)
-       (label-proc rect)))]
+       (label-proc outer-rect)))]
     [else '()]))

--- a/plot-lib/plot/private/no-gui/plot3d.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d.rkt
@@ -73,7 +73,7 @@
      (define bounds-rect (get-bounds-rect renderer-list x-min x-max y-min y-max z-min z-max))
      (define-values (x-ticks x-far-ticks y-ticks y-far-ticks z-ticks z-far-ticks)
        (get-ticks renderer-list bounds-rect))
-     (define legend-list (get-legend-list renderer-list bounds-rect))
+     (define legend-list (get-legend-entry-list renderer-list bounds-rect))
      
      (parameterize ([plot3d-angle        angle]
                     [plot3d-altitude     altitude]

--- a/plot-lib/plot/private/no-gui/plot3d.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d.rkt
@@ -40,7 +40,7 @@
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
           #:z-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          Void))
 (define (plot3d/dc renderer-tree dc x y width height
                    #:x-min [x-min #f] #:x-max [x-max #f]
@@ -73,6 +73,7 @@
      (define bounds-rect (get-bounds-rect renderer-list x-min x-max y-min y-max z-min z-max))
      (define-values (x-ticks x-far-ticks y-ticks y-far-ticks z-ticks z-far-ticks)
        (get-ticks renderer-list bounds-rect))
+     (define legend-list (get-legend-list renderer-list bounds-rect))
      
      (parameterize ([plot3d-angle        angle]
                     [plot3d-altitude     altitude]
@@ -83,6 +84,7 @@
                     [plot-legend-anchor  legend-anchor])
        (define area (make-object 3d-plot-area%
                       bounds-rect x-ticks x-far-ticks y-ticks y-far-ticks z-ticks z-far-ticks
+                      legend-list
                       dc x y width height))
        (plot-area area renderer-list))]))
 
@@ -107,7 +109,7 @@
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
           #:z-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          (Instance Bitmap%)))
 (define (plot3d-bitmap renderer-tree 
                        #:x-min [x-min #f] #:x-max [x-max #f]
@@ -145,7 +147,7 @@
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
           #:z-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          Pict))
 (define (plot3d-pict renderer-tree 
                      #:x-min [x-min #f] #:x-max [x-max #f]
@@ -186,7 +188,7 @@
           #:x-label (U String pict #f)
           #:y-label (U String pict #f)
           #:z-label (U String pict #f)
-          #:legend-anchor Anchor]
+          #:legend-anchor Legend-Anchor]
          Void))
 (define (plot3d-file renderer-tree output [kind 'auto]
                      #:x-min [x-min #f] #:x-max [x-max #f]

--- a/plot-lib/plot/private/plot2d/plot-area.rkt
+++ b/plot-lib/plot/private/plot2d/plot-area.rkt
@@ -683,9 +683,8 @@
       (define gap-size (+ (pen-gap) tick-radius))
       (define-values (x-min x-max y-min y-max)
         (if (outside-anchor (plot-legend-anchor))
-            (match-let ([(vector x-min y-min) (view->dc #(0. 0.))]
-                        [(vector x-max y-max) (view->dc #(1. 1.))])
-              (values x-min x-max y-min y-max))
+            (values dc-x-min (+ dc-x-min dc-x-size)
+                    dc-y-min (+ dc-y-min dc-y-size))
             (values area-x-min area-x-max area-y-min area-y-max)))
       (send pd draw-legend legend-entries
             (vector (ivl (+ x-min gap-size) (- x-max gap-size))

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -1286,9 +1286,8 @@
       (define gap-size (+ (pen-gap) tick-radius))
       (define-values (x-min x-max y-min y-max)
         (if (outside-anchor (plot-legend-anchor))
-            (match-let ([(vector x-min y-min) (view->dc (flvector 0. 0.))]
-                        [(vector x-max y-max) (view->dc (flvector 1. 1.))])
-              (values x-min x-max y-min y-max))
+            (values dc-x-min (+ dc-x-min dc-x-size)
+                    dc-y-min (+ dc-y-min dc-y-size))
             (values area-x-min area-x-max area-y-min area-y-max)))
       (send pd draw-legend legend-entries
             (vector (ivl (+ x-min gap-size) (- x-max gap-size))

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -97,7 +97,8 @@
                      [ry-ticks (Listof tick)]
                      [ry-far-ticks (Listof tick)]
                      [rz-ticks (Listof tick)]
-                     [rz-far-ticks (Listof tick)])
+                     [rz-far-ticks (Listof tick)]
+                     [legend (Listof legend-entry)])
          (init-field [dc (Instance DC<%>)]
                      [dc-x-min Real]
                      [dc-y-min Real]
@@ -145,7 +146,7 @@
 (: 3d-plot-area% 3D-Plot-Area%)
 (define 3d-plot-area%
   (class object%
-    (init-field bounds-rect rx-ticks rx-far-ticks ry-ticks ry-far-ticks rz-ticks rz-far-ticks)
+    (init-field bounds-rect rx-ticks rx-far-ticks ry-ticks ry-far-ticks rz-ticks rz-far-ticks legend)
     (init-field dc dc-x-min dc-y-min dc-x-size dc-y-size)
     (super-new)
     
@@ -1256,6 +1257,8 @@
     (define/public (start-plot)
       (send pd reset-drawing-params)
       (send pd clear)
+      (when (and (not (empty? legend)) (outside-anchor (plot-legend-anchor)))
+        (draw-legend legend))
       (draw-title)
       (draw-labels (get-back-label-params))
       (draw-ticks (get-back-tick-params))
@@ -1275,13 +1278,21 @@
       (send pd reset-drawing-params)
       (draw-front-axes)
       (draw-ticks (get-front-tick-params))
-      (draw-labels (get-front-label-params)))
+      (draw-labels (get-front-label-params))
+      (when (and (not (empty? legend)) (inside-anchor (plot-legend-anchor)))
+        (draw-legend legend)))
     
     (define/public (draw-legend legend-entries)
       (define gap-size (+ (pen-gap) tick-radius))
+      (define-values (x-min x-max y-min y-max)
+        (if (outside-anchor (plot-legend-anchor))
+            (match-let ([(vector x-min y-min) (view->dc (flvector 0. 0.))]
+                        [(vector x-max y-max) (view->dc (flvector 1. 1.))])
+              (values x-min x-max y-min y-max))
+            (values area-x-min area-x-max area-y-min area-y-max)))
       (send pd draw-legend legend-entries
-            (vector (ivl (+ area-x-min gap-size) (- area-x-max gap-size))
-                    (ivl (+ area-y-min gap-size) (- area-y-max gap-size)))))
+            (vector (ivl (+ x-min gap-size) (- x-max gap-size))
+                    (ivl (+ y-min gap-size) (- y-max gap-size)))))
     
     (define/public (end-plot)
       (send pd restore-drawing-params))

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -17,7 +17,8 @@
  Alphas
  Labels
  Contour-Levels
- Image-File-Format)
+ Image-File-Format
+ Legend-Anchor)
 
 (require "common/math.rkt")
 


### PR DESCRIPTION
This build on #70 and #71 in order to implement #49.

Although all test pass, a little improvement can be made (changing 3 test cases), see [plot2d-utils#L73](https://github.com/racket/plot/blob/939390c7b3d5a858d7f1c5af2b246211bdbff83d/plot-lib/plot/private/no-gui/plot2d-utils.rkt#L73) and [plot3d-utils#L83](https://github.com/racket/plot/blob/939390c7b3d5a858d7f1c5af2b246211bdbff83d/plot-lib/plot/private/no-gui/plot3d-utils.rkt#L83)