### PR TITLE
3dsnip: center the interactive message on the plot area

### DIFF
--- a/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
@@ -19,9 +19,11 @@
 (define-type Make-3D-Plot-Snip
   (-> (Instance Bitmap%)
       Plot-Parameters
-      (-> Boolean Real Real Positive-Integer Positive-Integer (Instance Bitmap%))
+      (-> Boolean Real Real Positive-Integer Positive-Integer
+          (Values (Instance Bitmap%) (U #f (Instance 3D-Plot-Area%))))
       Real
       Real
+      (U #f (Instance 3D-Plot-Area%))
       Positive-Integer
       Positive-Integer
       (Instance Snip%)))

--- a/plot-gui-lib/plot/private/gui/lazy-snip-untyped.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-untyped.rkt
@@ -20,10 +20,10 @@
 
 (define (-make-3d-plot-snip
          init-bm saved-plot-parameters
-         make-bm angle altitude width height)
+         make-bm angle altitude area width height)
   (make-3d-plot-snip
    init-bm saved-plot-parameters
-   make-bm angle altitude width height))
+   make-bm angle altitude area width height))
 
 (define (-make-snip-frame snip width height label)
   (make-snip-frame snip width height label))

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -93,7 +93,7 @@
     ;; For 3D legend can be calculated once since we don't change the bounding box
     (define legend (get-legend-entry-list renderer-list bounds-rect))
 
-    (: make-bm (-> Boolean Real Real Positive-Integer Positive-Integer (Instance Bitmap%)))
+    (: make-bm (-> Boolean Real Real Positive-Integer Positive-Integer (Values (Instance Bitmap%) (U #f (Instance 3D-Plot-Area%)))))
     (define (make-bm anim? angle altitude width height)
       (parameterize/group ([plot-parameters  saved-plot-parameters]
                            [plot-animating?  (if anim? #t (plot-animating?))]
@@ -124,11 +124,12 @@
 
         (send area end-renderers)
         (send area end-plot)
-        bm))
+        (values bm area)))
 
+    (define-values (bm area) (make-bm #f angle altitude width height))
     (make-3d-plot-snip
-     (make-bm #f angle altitude width height) saved-plot-parameters
-     make-bm angle altitude width height)))
+     bm saved-plot-parameters
+     make-bm angle altitude area width height)))
 
 ;; ===================================================================================================
 ;; Plot to a frame

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -114,6 +114,7 @@
          [get-z-far-ticks (-> (Listof tick))]
          [get-bounds-rect (-> Rect)]
          [get-clip-rect (-> Rect)]
+         [get-area-bounds-rect (-> Rect)]
          [get-render-tasks  (-> render-tasks)]
          [set-render-tasks  (-> render-tasks Void)]
          [start-plot (-> Void)]
@@ -969,6 +970,9 @@
     (define area-y-min top)
     (define area-y-max (- dc-y-size bottom))
     
+    (define/public (get-area-bounds-rect)
+      (vector (ivl area-x-min area-x-max) (ivl area-y-min area-y-max)))
+
     ;; ===============================================================================================
     ;; Plot decoration
     


### PR DESCRIPTION
Previously the plot-area for plot3d was equal to the `plot-width` × `plot-height`. With the recent changes (pict->title and legend outside plot-area) the actual plot-area can be quite different.
This PR brings the plot3d in line with plot (2D) where interactive messages (such as angle / altitude) are centered on the plot-area.