### PR TITLE
minor fix for intro doc

### DIFF
--- a/plot-doc/plot/scribblings/intro.scrbl
+++ b/plot-doc/plot/scribblings/intro.scrbl
@@ -105,7 +105,7 @@ Clearly, the blue-colored interval between sine waves is drawn first.
 
 @section{Renderer and Plot Bounds}
 
-In the preceeding example, the @italic{x}-axis @tech{bounds} are passed to @(racket plot) using the keyword arguments @(racket #:x-min) and @(racket x-max).
+In the preceeding example, the @italic{x}-axis @tech{bounds} are passed to @(racket plot) using the keyword arguments @(racket #:x-min) and @(racket #:x-max).
 The bounds could easily have been passed in either call to @(racket function-interval) instead.
 In both cases, @(racket plot) and @(racket function-interval) work together to determine @italic{y}-axis @tech{bounds} large enough for both renderers.
 


### PR DESCRIPTION
I also wanna ask why `plot3d`'s output feels weird when `#:altitude` is not `25`:

```racket
(plot3d (polar3d (λ (θ ρ) 1) #:color 2 #:line-style 'transparent)
        #:altitude 0 #:angle 0)
```

Shouldn't this code output a circle instead of an ellipse?