### PR TITLE
make CI build from the repository and not from the catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
       # the failure is specific to a Racket version.
       fail-fast: false
       matrix:
-        racket-version: ["7.9", "current"]
-        racket-variant: ["regular", "CS"]
+        racket-version: ["8.0", "current"]
+        racket-variant: ["BC", "CS"]
     steps:
       - uses: actions/checkout@v2
-      - uses: Bogdanp/setup-racket@v0.10
+      - uses: Bogdanp/setup-racket@v1.1
         with:
           architecture: x64
           distribution: minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,34 +19,36 @@ jobs:
           distribution: minimal
           variant: ${{ matrix.racket-variant }}
           version: ${{ matrix.racket-version }}
+          dest: '${HOME}/racket'
+          sudo: never
 
       # Setup this source repository as a package catalog which has higher
       # priority than the main catalog
 
-      - run: racket -l- pkg/dirs-catalog --link catalog .
+      - run: ${HOME}/racket/bin/racket -l- pkg/dirs-catalog --link catalog .
       - run: echo "file://`pwd`/catalog" > catalogs.txt
-      - run: raco pkg config catalogs >> catalogs.txt
-      - run: raco pkg config --set catalogs `cat catalogs.txt`
-      - run: raco pkg config catalogs
+      - run: ${HOME}/racket/bin/raco pkg config catalogs >> catalogs.txt
+      - run: ${HOME}/racket/bin/raco pkg config --set catalogs `cat catalogs.txt`
+      - run: ${HOME}/racket/bin/raco pkg config catalogs
 
       # Install plot and its dependencies.  Since we installed minimal racket,
       # this will fetch most of the packages from the main package catalog,
       # except for the packages inside this directory, which have higher
       # priority.
 
-      - run: sudo raco pkg install --batch --auto plot
+      - run: ${HOME}/racket/bin/raco pkg install --batch --auto plot
 
       # This runs any tests inside the plot, plot-lib, plot-gui-lib and
       # plot-doc packages, but NOT the plot-test package.  The actual tests
       # are in the `plot-test` package, so we don't expect any tests here, but
       # just in case someone wrote a test module...
 
-      - run: sudo xvfb-run raco test --deps --package plot
+      - run: xvfb-run ${HOME}/racket/bin/raco test --deps --package plot
 
       # Install the plot-test package and run the tests
         
-      - run: sudo raco pkg install --batch --auto plot-test
-      - run: sudo xvfb-run raco test --package plot-test
+      - run: ${HOME}/racket/bin/raco pkg install --batch --auto plot-test
+      - run: xvfb-run ${HOME}/racket/bin/raco test --package plot-test
 
       # If any of the plot-test tests failed, they will generate new draw step
       # files and sample images.  Upload these as an Github Actions Artifact,


### PR DESCRIPTION
This likely also fixes the CI issue from #86 (...somehow). Looking through the logs of the CI build:
```
Resolved "plot" via file:///home/runner/work/plot/plot/catalog
00: Resolved "plot-lib" via file:///home/runner/work/plot/plot/catalog
00: Resolved "plot-gui-lib" via file:///home/runner/work/plot/plot/catalog
Resolved "plot-doc" via file:///home/runner/work/plot/plot/catalog
```