### PR TITLE
Plotmetrics

### DIFF
--- a/plot-gui-lib/plot/private/gui/lazy-snip-typed.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-typed.rkt
@@ -6,7 +6,8 @@
 
 (provide make-2d-plot-snip
          make-3d-plot-snip
-         make-snip-frame)
+         make-snip-frame
+         Plot-Snip%)
 
 (type-environment
  [make-2d-plot-snip  (parse-type #'Make-2D-Plot-Snip)]

--- a/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
+++ b/plot-gui-lib/plot/private/gui/lazy-snip-types.rkt
@@ -5,6 +5,8 @@
 
 (provide (all-defined-out))
 
+(define-type Plot-Snip% (Class #:implements Snip% #:implements Plot-Metrics<%>))
+
 (define-type Make-2D-Plot-Snip
   (-> (Instance Bitmap%)
       Plot-Parameters
@@ -14,7 +16,7 @@
       (U #f (Instance 2D-Plot-Area%))
       Positive-Integer
       Positive-Integer
-      (Instance Snip%)))
+      (Instance Plot-Snip%)))
 
 (define-type Make-3D-Plot-Snip
   (-> (Instance Bitmap%)
@@ -26,7 +28,7 @@
       (U #f (Instance 3D-Plot-Area%))
       Positive-Integer
       Positive-Integer
-      (Instance Snip%)))
+      (Instance Plot-Snip%)))
 
 (define-type Make-Snip-Frame
   (-> (-> Positive-Integer Positive-Integer (Instance Snip%))

--- a/plot-gui-lib/plot/private/gui/plot2d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot2d.rkt
@@ -68,7 +68,7 @@
           #:y-label (U String pict #f)
           #:aspect-ratio (U Nonnegative-Real #f)
           #:legend-anchor Legend-Anchor]
-         (Instance Snip%)))
+         (Instance Plot-Snip%)))
 (define (plot-snip renderer-tree
                    #:x-min [x-min #f] #:x-max [x-max #f]
                    #:y-min [y-min #f] #:y-max [y-max #f]

--- a/plot-gui-lib/plot/private/gui/plot3d.rkt
+++ b/plot-gui-lib/plot/private/gui/plot3d.rkt
@@ -46,7 +46,7 @@
           #:z-label (U String pict #f)
           #:aspect-ratio (U Nonnegative-Real #f)
           #:legend-anchor Legend-Anchor]
-         (Instance Snip%)))
+         (Instance Plot-Snip%)))
 (define (plot3d-snip renderer-tree
                      #:x-min [x-min #f] #:x-max [x-max #f]
                      #:y-min [y-min #f] #:y-max [y-max #f]

--- a/plot-gui-lib/plot/private/gui/snip2d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip2d.rkt
@@ -389,7 +389,7 @@
     (define/public (get-plot-bounds) (unless plot-metrics-ok? (update-metrics)) (bounds))
     (define/public (plot->dc coords) (unless plot-metrics-ok? (update-metrics)) (->dc coords))
     (define/public (dc->plot coords) (unless plot-metrics-ok? (update-metrics)) (->plot coords))
-    (define/public (plane-vector coords) (unless plot-metrics-ok? (update-metrics)) (plane))
+    (define/public (plane-vector)    (unless plot-metrics-ok? (update-metrics)) (plane))
     (define/public (get-plot-metrics-functions) (unless plot-metrics-ok? (update-metrics)) (list bounds ->dc ->plot plane))
     ))
 

--- a/plot-gui-lib/plot/private/gui/snip2d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip2d.rkt
@@ -372,6 +372,12 @@
         (start-update-thread #f)
         (set-update #t))
       (super resize w h))
+
+    (define/public (get-plot-bounds)
+      (match-define (vector (ivl xmin xmax) (ivl ymin ymax))
+        (send area get-bounds-rect))
+      (vector (vector xmin xmax) (vector ymin ymax)))
+    (define/public (plot->dc coords) (send area plot->dc coords))
     ))
 
 (define (make-2d-plot-snip

--- a/plot-gui-lib/plot/private/gui/snip3d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip3d.rkt
@@ -140,6 +140,12 @@
           (start-update-thread #t))
         (set-update #t))
       (super resize w h))
+
+    (define/public (get-plot-bounds)
+      (match-define (vector (ivl xmin xmax) (ivl ymin ymax) (ivl zmin zmax))
+        (send area get-bounds-rect))
+      (vector (vector xmin xmax) (vector ymin ymax) (vector zmin zmax)))
+    (define/public (plot->dc coords) (send area plot->dc coords))
     ))
 
 (define (make-3d-plot-snip

--- a/plot-gui-lib/plot/private/gui/snip3d.rkt
+++ b/plot-gui-lib/plot/private/gui/snip3d.rkt
@@ -157,7 +157,7 @@
     (define/public (get-plot-bounds) (unless plot-metrics-ok? (update-metrics)) (bounds))
     (define/public (plot->dc coords) (unless plot-metrics-ok? (update-metrics)) (->dc coords))
     (define/public (dc->plot coords) (unless plot-metrics-ok? (update-metrics)) (->plot coords))
-    (define/public (plane-vector coords) (unless plot-metrics-ok? (update-metrics)) (plane))
+    (define/public (plane-vector)    (unless plot-metrics-ok? (update-metrics)) (plane))
     (define/public (get-plot-metrics-functions) (unless plot-metrics-ok? (update-metrics)) (list bounds ->dc ->plot plane))
     ))
 

--- a/plot-lib/plot/private/common/contract.rkt
+++ b/plot-lib/plot/private/common/contract.rkt
@@ -121,3 +121,8 @@
 (define (treeof elem-contract)
   (or/c elem-contract
         (listof (recursive-contract (treeof elem-contract) #:flat))))
+
+(define plot-metrics<%>/c
+  (object/c [get-plot-bounds (->m (-> (vectorof (vector/c real? real?))))]
+            [plot->dc (->m (vectorof real?) (vectorof real?))]))
+

--- a/plot-lib/plot/private/common/contract.rkt
+++ b/plot-lib/plot/private/common/contract.rkt
@@ -122,7 +122,5 @@
   (or/c elem-contract
         (listof (recursive-contract (treeof elem-contract) #:flat))))
 
-(define plot-metrics<%>/c
-  (object/c [get-plot-bounds (->m (-> (vectorof (vector/c real? real?))))]
-            [plot->dc (->m (vectorof real?) (vectorof real?))]))
-
+(require (submod "plotmetrics.rkt" untyped))
+(provide plot-metrics-object/c)

--- a/plot-lib/plot/private/common/plotmetrics.rkt
+++ b/plot-lib/plot/private/common/plotmetrics.rkt
@@ -1,0 +1,97 @@
+#lang typed/racket/base
+
+;; Untyped interface / contract
+(module untyped racket/base
+  (require racket/class
+           racket/contract
+           racket/match
+           racket/draw)
+
+  (provide plot-metrics<%>
+           plot-metrics-object/c)
+
+  (define plot-metrics<%> (interface ()
+                            get-plot-bounds
+                            dc->plot
+                            plot->dc
+                            plane-vector
+                            get-plot-metrics-functions))
+
+  (define plot-metrics-object/c
+    (object/c [get-plot-bounds            (->m (-> (vectorof (vector/c real? real?))))]
+              [plot->dc                   (->m (vectorof real?) (vectorof real?))]
+              [dc->plot                   (->m (vectorof real?) (vectorof real?))]
+              [plane-vector               (->m (vectorof real?))]
+              [get-plot-metrics-functions (->m (values (-> (vectorof (vector/c real? real?)))
+                                                       (-> (vectorof real?) (vectorof real?))
+                                                       (-> (vectorof real?) (vectorof real?))
+                                                       (-> (vectorof real?))))]))
+  )
+
+;; Typed  Types / mixin / structures
+(require typed/pict
+         typed/racket/class
+         racket/match)
+  
+(provide plot-metrics-mixin Plot-Metrics-Functions Plot-Metrics<%> plot-metrics%
+         (struct-out plot-pict) Plot-Pict pict->pp)
+
+(define-type Metrics-Object (Object [get-plot-metrics-functions (-> Plot-Metrics-Functions)]))
+(define-type Plot-Metrics-Functions (List (-> (Vectorof (Vectorof Real)))
+                                          (-> (Vectorof Real) (Vectorof Real))
+                                          (-> (Vectorof Real) (Vectorof Real))
+                                          (-> (Vectorof Real))))
+(define-type Plot-Metrics<%>
+  (Class
+   [get-plot-bounds (-> (Vectorof (Vectorof Real)))]
+   [plot->dc        (-> (Vectorof Real) (Vectorof Real))]
+   [dc->plot        (-> (Vectorof Real) (Vectorof Real))]
+   [plane-vector    (-> (Vectorof Real))]
+   [get-plot-metrics-functions (-> Plot-Metrics-Functions)]))
+
+(: plot-metrics-mixin (All (A #:row) (-> (Class #:row-var A)
+                                         (Class [init [->metrics-object (-> Metrics-Object)]]
+                                                #:row-var A
+                                                #:implements Plot-Metrics<%>))))
+(define (plot-metrics-mixin %)
+  (class %
+    (init ->metrics-object)
+    (define (load) : Void
+      (match-define (list new-bounds new-->dc new-->plot new-plane)
+        (send (->metrics-object) get-plot-metrics-functions))
+      (set! bounds new-bounds)
+      (set! ->dc new-->dc)
+      (set! ->plot new-->plot)
+      (set! plane new-plane)
+      (set! getall (λ () (list bounds ->dc ->plot plane)))
+      (set! load void))
+
+    (define (bounds) : (Vectorof (Vectorof Real)) (load)(bounds))
+    (define (plane)  : (Vectorof Real)            (load)(plane))
+    (define (getall) : Plot-Metrics-Functions     (load)(list bounds ->dc ->plot plane))
+    (define (->dc   [v : (Vectorof Real)]) : (Vectorof Real) (load)(->dc v))
+    (define (->plot [v : (Vectorof Real)]) : (Vectorof Real) (load)(->plot v))
+      
+    (super-make-object)
+    (define/public (get-plot-bounds) (bounds))
+    (define/public (dc->plot coords) (->plot coords))
+    (define/public (plot->dc coords) (->dc coords))
+    (define/public (plane-vector) (plane))
+    (define/public (get-plot-metrics-functions) (getall))))
+
+(define plot-metrics% (plot-metrics-mixin object%))
+
+
+(struct plot-pict pict ([bounds : (Vectorof (Vectorof Real))]
+                        [plot->dc : (-> (Vectorof Real) (Vectorof Real))]
+                        [dc->plot : (-> (Vectorof Real) (Vectorof Real))]
+                        [plane-vector : (Vectorof Real)]))
+(define-type Plot-Pict plot-pict)
+(define (pict->pp [P : pict]
+                  [metrics-object : Metrics-Object]) : plot-pict
+  (match-define (list bounds ->dc ->plot plane)
+    (send metrics-object get-plot-metrics-functions))
+  
+  (plot-pict (pict-draw P) (pict-width P) (pict-height P) (pict-ascent P)
+             (pict-descent P) (pict-children P) (pict-panbox P) (pict-last P)
+             (bounds) ->dc ->plot (plane)))

--- a/plot-lib/plot/private/common/plotmetrics.rkt
+++ b/plot-lib/plot/private/common/plotmetrics.rkt
@@ -18,7 +18,7 @@
                             get-plot-metrics-functions))
 
   (define plot-metrics-object/c
-    (object/c [get-plot-bounds            (->m (-> (vectorof (vector/c real? real?))))]
+    (object/c [get-plot-bounds            (->m (vectorof (vector/c real? real?)))]
               [plot->dc                   (->m (vectorof real?) (vectorof real?))]
               [dc->plot                   (->m (vectorof real?) (vectorof real?))]
               [plane-vector               (->m (vectorof real?))]

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -162,3 +162,17 @@
    [draw-pict (->* [pict (Vectorof Real)] (Anchor Real) Void)]
    [calculate-legend-rect (-> (Listof legend-entry) Rect Anchor Rect)]
    [draw-legend (-> (Listof legend-entry) Rect Void)]))
+
+(define-type Plot-Metrics<%>
+  (Class
+   [get-plot-bounds (-> (Vectorof (Vector Real Real)))]
+   [plot->dc (-> (Vectorof Real) (Vectorof Real))]))
+
+(struct plotpict pict ([bounds : (Vectorof (Vector Real Real))]
+                        [plot->dc : (-> (Vector Real Real) (Vectorof Real))]))
+(define (pict->pp [P : pict]
+                  [bounds : (Vectorof (Vector Real Real))]
+                  [->dc : (-> (Vector Real Real) (Vectorof Real))]) : plotpict
+  (plotpict (pict-draw P) (pict-width P) (pict-height P) (pict-ascent P) (pict-descent P) (pict-children P) (pict-panbox P) (pict-last P)
+             bounds ->dc))
+

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -170,6 +170,7 @@
 
 (struct plotpict pict ([bounds : (Vectorof (Vector Real Real))]
                         [plot->dc : (-> (Vector Real Real) (Vectorof Real))]))
+(define-type PlotPict plotpict)
 (define (pict->pp [P : pict]
                   [bounds : (Vectorof (Vector Real Real))]
                   [->dc : (-> (Vector Real Real) (Vectorof Real))]) : plotpict

--- a/plot-lib/plot/private/common/types.rkt
+++ b/plot-lib/plot/private/common/types.rkt
@@ -163,17 +163,5 @@
    [calculate-legend-rect (-> (Listof legend-entry) Rect Anchor Rect)]
    [draw-legend (-> (Listof legend-entry) Rect Void)]))
 
-(define-type Plot-Metrics<%>
-  (Class
-   [get-plot-bounds (-> (Vectorof (Vector Real Real)))]
-   [plot->dc (-> (Vectorof Real) (Vectorof Real))]))
-
-(struct plotpict pict ([bounds : (Vectorof (Vector Real Real))]
-                        [plot->dc : (-> (Vector Real Real) (Vectorof Real))]))
-(define-type PlotPict plotpict)
-(define (pict->pp [P : pict]
-                  [bounds : (Vectorof (Vector Real Real))]
-                  [->dc : (-> (Vector Real Real) (Vectorof Real))]) : plotpict
-  (plotpict (pict-draw P) (pict-width P) (pict-height P) (pict-ascent P) (pict-descent P) (pict-children P) (pict-panbox P) (pict-last P)
-             bounds ->dc))
-
+(require "plotmetrics.rkt")
+(provide Plot-Metrics<%> Plot-Pict Plot-Metrics-Functions)

--- a/plot-lib/plot/private/no-gui/evil-types.rkt
+++ b/plot-lib/plot/private/no-gui/evil-types.rkt
@@ -5,6 +5,3 @@
 (provide Pict pict?)
 
 (define-type Pict pict)
-#;(require/typed
- pict
- [#:opaque Pict pict?])

--- a/plot-lib/plot/private/no-gui/evil-types.rkt
+++ b/plot-lib/plot/private/no-gui/evil-types.rkt
@@ -1,7 +1,10 @@
 #lang typed/racket
 
+(require typed/pict)
+
 (provide Pict pict?)
 
-(require/typed
+(define-type Pict pict)
+#;(require/typed
  pict
  [#:opaque Pict pict?])

--- a/plot-lib/plot/private/no-gui/plot-bitmap.rkt
+++ b/plot-lib/plot/private/no-gui/plot-bitmap.rkt
@@ -26,7 +26,7 @@
           #:legend-anchor Anchor
           #:out-file (U Path-String Output-Port #f)
           #:out-kind (U 'auto Image-File-Format)]
-         (Instance Bitmap%)))
+         (Instance (Class #:implements Bitmap% #:implements Plot-Metrics<%>))))
 (define (plot renderer-tree
               #:x-min [x-min #f] #:x-max [x-max #f]
               #:y-min [y-min #f] #:y-max [y-max #f]
@@ -66,7 +66,7 @@
           #:legend-anchor Anchor
           #:out-file (U Path-String Output-Port #f)
           #:out-kind (U 'auto Image-File-Format)]
-         (Instance Bitmap%)))
+         (Instance (Class #:implements Bitmap% #:implements Plot-Metrics<%>))))
 (define (plot3d renderer-tree
                 #:x-min [x-min #f] #:x-max [x-max #f]
                 #:y-min [y-min #f] #:y-max [y-max #f]

--- a/plot-lib/plot/private/no-gui/plot-pict.rkt
+++ b/plot-lib/plot/private/no-gui/plot-pict.rkt
@@ -25,7 +25,7 @@
           #:legend-anchor Anchor
           #:out-file (U Path-String Output-Port #f)
           #:out-kind (U 'auto Image-File-Format)]
-         Pict))
+         PlotPict))
 (define (plot renderer-tree
               #:x-min [x-min #f] #:x-max [x-max #f]
               #:y-min [y-min #f] #:y-max [y-max #f]
@@ -65,7 +65,7 @@
           #:legend-anchor Anchor
           #:out-file (U Path-String Output-Port #f)
           #:out-kind (U 'auto Image-File-Format)]
-         Pict))
+         PlotPict))
 (define (plot3d renderer-tree
                 #:x-min [x-min #f] #:x-max [x-max #f]
                 #:y-min [y-min #f] #:y-max [y-max #f]

--- a/plot-lib/plot/private/no-gui/plot-pict.rkt
+++ b/plot-lib/plot/private/no-gui/plot-pict.rkt
@@ -25,7 +25,7 @@
           #:legend-anchor Anchor
           #:out-file (U Path-String Output-Port #f)
           #:out-kind (U 'auto Image-File-Format)]
-         PlotPict))
+         Plot-Pict))
 (define (plot renderer-tree
               #:x-min [x-min #f] #:x-max [x-max #f]
               #:y-min [y-min #f] #:y-max [y-max #f]
@@ -65,7 +65,7 @@
           #:legend-anchor Anchor
           #:out-file (U Path-String Output-Port #f)
           #:out-kind (U 'auto Image-File-Format)]
-         PlotPict))
+         Plot-Pict))
 (define (plot3d renderer-tree
                 #:x-min [x-min #f] #:x-max [x-max #f]
                 #:y-min [y-min #f] #:y-max [y-max #f]

--- a/plot-lib/plot/private/no-gui/plot2d-untyped.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d-untyped.rkt
@@ -28,7 +28,7 @@
          #:y-label (or/c string? pict? #f)
          #:aspect-ratio (or/c (and/c rational? positive?) #f)
          #:legend-anchor legend-anchor/c]
-        void?)]
+        plot-metrics<%>/c)]
    [untyped-plot-bitmap
     (->* [(treeof (or/c renderer2d? nonrenderer?))]
          [#:x-min (or/c real? #f)
@@ -42,7 +42,7 @@
           #:y-label (or/c string? pict? #f)
           #:aspect-ratio (or/c (and/c rational? positive?) #f)
           #:legend-anchor legend-anchor/c]
-         (is-a?/c bitmap%))]
+         (and/c (is-a?/c bitmap%) plot-metrics<%>/c))]
     [untyped-plot-pict
      (->* [(treeof (or/c renderer2d? nonrenderer?))]
           [#:x-min (or/c real? #f)
@@ -56,7 +56,7 @@
            #:y-label (or/c string? pict? #f)
            #:aspect-ratio (or/c (and/c rational? positive?) #f)
            #:legend-anchor legend-anchor/c]
-          pict?)]))
+          plotpict?)]))
 
 (define untyped-plot/dc plot/dc)
 (define untyped-plot-pict plot-pict)

--- a/plot-lib/plot/private/no-gui/plot2d-untyped.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d-untyped.rkt
@@ -28,7 +28,7 @@
          #:y-label (or/c string? pict? #f)
          #:aspect-ratio (or/c (and/c rational? positive?) #f)
          #:legend-anchor legend-anchor/c]
-        plot-metrics<%>/c)]
+        plot-metrics-object/c)]
    [untyped-plot-bitmap
     (->* [(treeof (or/c renderer2d? nonrenderer?))]
          [#:x-min (or/c real? #f)
@@ -42,7 +42,7 @@
           #:y-label (or/c string? pict? #f)
           #:aspect-ratio (or/c (and/c rational? positive?) #f)
           #:legend-anchor legend-anchor/c]
-         (and/c (is-a?/c bitmap%) plot-metrics<%>/c))]
+         (and/c (is-a?/c bitmap%) plot-metrics-object/c))]
     [untyped-plot-pict
      (->* [(treeof (or/c renderer2d? nonrenderer?))]
           [#:x-min (or/c real? #f)
@@ -56,7 +56,7 @@
            #:y-label (or/c string? pict? #f)
            #:aspect-ratio (or/c (and/c rational? positive?) #f)
            #:legend-anchor legend-anchor/c]
-          plotpict?)]))
+          plot-pict?)]))
 
 (define untyped-plot/dc plot/dc)
 (define untyped-plot-pict plot-pict)

--- a/plot-lib/plot/private/no-gui/plot2d.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d.rkt
@@ -138,7 +138,7 @@
           #:y-label (U String pict #f)
           #:aspect-ratio (U Nonnegative-Real #f)
           #:legend-anchor Legend-Anchor]
-         plotpict))
+         PlotPict))
 (define (plot-pict renderer-tree
                    #:x-min [x-min #f] #:x-max [x-max #f]
                    #:y-min [y-min #f] #:y-max [y-max #f]

--- a/plot-lib/plot/private/no-gui/plot2d.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d.rkt
@@ -16,32 +16,13 @@
          "../plot2d/renderer.rkt"
          "plot2d-utils.rkt"
          "../common/math.rkt"
-         (only-in "evil.rkt" new-post-script-dc% new-pdf-dc% new-svg-dc%)
+         (except-in "evil.rkt" dc)
          typed/racket/unsafe)
 
 (unsafe-provide plot/dc
                 plot-bitmap
                 plot-pict
-                plot-file
-                plotpict-bounds
-                plotpict-plot->dc)
-
-;; ===================================================================================================
-;; Extra types
-
-(define-type Plot-Metrics<%>
-  (Class
-   [get-plot-bounds (-> (Vector (Vector Real Real) (Vector Real Real)))]
-   [plot->dc (-> (Vectorof Real) (Vectorof Real))]))
-
-(struct plotpict pict ([bounds : (Vector (Vector Real Real) (Vector Real Real))]
-                        [plot->dc : (-> (Vector Real Real) (Vectorof Real))]))
-(define (pict->pp [P : pict]
-                  [bounds : (Vector (Vector Real Real) (Vector Real Real))]
-                  [->dc : (-> (Vector Real Real) (Vectorof Real))]) : plotpict
-  (plotpict (pict-draw P) (pict-width P) (pict-height P) (pict-ascent P) (pict-descent P) (pict-children P) (pict-panbox P) (pict-last P)
-             bounds ->dc))
-
+                plot-file)
 
 ;; ===================================================================================================
 ;; Plot to a given device context

--- a/plot-lib/plot/private/no-gui/plot2d.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d.rkt
@@ -104,8 +104,7 @@
                      #:aspect-ratio [aspect-ratio (plot-aspect-ratio)]
                      #:legend-anchor [legend-anchor (plot-legend-anchor)])
   (define bm : (Instance (Class #:implements Bitmap% #:implements Plot-Metrics<%>))
-    (make-object (plot-metrics-mixin bitmap%)
-      (λ () pm) width height #t 1.0))
+    (make-object (plot-metrics-mixin bitmap%) (λ () pm) width height))
   (define dc : (Instance DC<%>) (make-object bitmap-dc% bm))
   (define pm : (Instance Plot-Metrics<%>)
     (plot/dc renderer-tree dc 0 0 width height

--- a/plot-lib/plot/private/no-gui/plot3d-untyped.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d-untyped.rkt
@@ -34,7 +34,7 @@
          #:z-label (or/c string? pict? #f)
          #:aspect-ratio (or/c (and/c rational? positive?) #f)
          #:legend-anchor legend-anchor/c]
-        void?)]))
+        plot-metrics<%>/c)]))
 
 (define-syntax untyped-plot3d/dc
   (make-rename-transformer (unbox plot3d/dc-box)))

--- a/plot-lib/plot/private/no-gui/plot3d-untyped.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d-untyped.rkt
@@ -34,7 +34,7 @@
          #:z-label (or/c string? pict? #f)
          #:aspect-ratio (or/c (and/c rational? positive?) #f)
          #:legend-anchor legend-anchor/c]
-        plot-metrics<%>/c)]))
+        plot-metrics-object/c)]))
 
 (define-syntax untyped-plot3d/dc
   (make-rename-transformer (unbox plot3d/dc-box)))

--- a/plot-lib/plot/private/no-gui/plot3d.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d.rkt
@@ -12,6 +12,7 @@
          "../common/nonrenderer.rkt"
          "../common/file-type.rkt"
          "../common/utils.rkt"
+         "../common/plotmetrics.rkt"
          "../plot3d/plot-area.rkt"
          "../plot3d/renderer.rkt"
          "plot3d-utils.rkt"
@@ -93,16 +94,7 @@
                       dc x y width height aspect-ratio))
        (plot-area area renderer-list)
 
-       (define bounds (vector (vector (assert (ivl-min (vector-ref bounds-rect 0)) real?)
-                                      (assert (ivl-max (vector-ref bounds-rect 0)) real?))
-                              (vector (assert (ivl-min (vector-ref bounds-rect 1)) real?)
-                                      (assert (ivl-max (vector-ref bounds-rect 1)) real?))
-                              (vector (assert (ivl-min (vector-ref bounds-rect 2)) real?)
-                                      (assert (ivl-max (vector-ref bounds-rect 2)) real?))))
-       (new (class object%
-              (super-new)
-              (define/public (get-plot-bounds) bounds)
-              (define/public (plot->dc [v : (Vectorof Real)]) (send area plot->dc v)))))]))
+       (new plot-metrics% [->metrics-object (λ () area)]))]))
 
 (require (for-syntax racket/base
                      "plot3d-evil-box.rkt"))
@@ -143,10 +135,8 @@
                        #:aspect-ratio [aspect-ratio (plot-aspect-ratio)]
                        #:legend-anchor [legend-anchor (plot-legend-anchor)])
   (define bm : (Instance (Class #:implements Bitmap% #:implements Plot-Metrics<%>))
-    (new (class bitmap%
-           (super-make-object width height #t 1.0)
-           (define/public (get-plot-bounds) (send pm get-plot-bounds))
-           (define/public (plot->dc [v : (Vectorof Real)]) (send pm plot->dc v)))))
+    (make-object (plot-metrics-mixin (class bitmap% (super-new)))
+      (λ () pm) width height #t 1.0))
   (define dc : (Instance DC<%>) (make-object bitmap-dc% bm))
   (define pm : (Instance Plot-Metrics<%>)
     (plot3d/dc renderer-tree dc 0 0 width height
@@ -172,7 +162,7 @@
           #:z-label (U String pict #f)
           #:aspect-ratio (U Nonnegative-Real #f)
           #:legend-anchor Legend-Anchor]
-         plotpict))
+         Plot-Pict))
 (define (plot3d-pict renderer-tree
                      #:x-min [x-min #f] #:x-max [x-max #f]
                      #:y-min [y-min #f] #:y-max [y-max #f]
@@ -199,11 +189,7 @@
                                                #:y-label y-label #:z-label z-label #:legend-anchor legend-anchor
                                                #:aspect-ratio aspect-ratio))))
         width height))
-  (pict->pp
-   P
-   (send (assert pm) get-plot-bounds)
-   (λ ([v : (Vector Real Real)])
-     (send (assert pm) plot->dc v))))
+  (pict->pp P (assert pm)))
 
 ;; ===================================================================================================
 ;; Plot to any supported kind of file

--- a/plot-lib/plot/private/no-gui/plot3d.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d.rkt
@@ -127,7 +127,7 @@
           #:z-label (U String pict #f)
           #:aspect-ratio (U Nonnegative-Real #f)
           #:legend-anchor Legend-Anchor]
-         (Instance Bitmap%)))
+         (Instance (Class #:implements Bitmap% #:implements Plot-Metrics<%>))))
 (define (plot3d-bitmap renderer-tree
                        #:x-min [x-min #f] #:x-max [x-max #f]
                        #:y-min [y-min #f] #:y-max [y-max #f]

--- a/plot-lib/plot/private/no-gui/plot3d.rkt
+++ b/plot-lib/plot/private/no-gui/plot3d.rkt
@@ -135,8 +135,7 @@
                        #:aspect-ratio [aspect-ratio (plot-aspect-ratio)]
                        #:legend-anchor [legend-anchor (plot-legend-anchor)])
   (define bm : (Instance (Class #:implements Bitmap% #:implements Plot-Metrics<%>))
-    (make-object (plot-metrics-mixin (class bitmap% (super-new)))
-      (λ () pm) width height #t 1.0))
+    (make-object (plot-metrics-mixin (class bitmap% (super-new))) (λ () pm) width height))
   (define dc : (Instance DC<%>) (make-object bitmap-dc% bm))
   (define pm : (Instance Plot-Metrics<%>)
     (plot3d/dc renderer-tree dc 0 0 width height

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -124,6 +124,7 @@
          [end-renderers (-> Void)]
          [draw-legend (-> (Listof legend-entry) Void)]
          [end-plot (-> Void)]
+         [plot->dc (-> (Vectorof Real) (Vectorof Real))]
          [put-alpha  (-> Nonnegative-Real Void)]
          [put-pen (-> Plot-Color Nonnegative-Real Plot-Pen-Style Void)]
          [put-major-pen (->* [] [Plot-Pen-Style] Void)]
@@ -335,7 +336,7 @@
     
     (: plot->dc (-> (Vectorof Real) (Vectorof Real)))
     (: norm->dc (-> FlVector (Vectorof Real)))    
-    (define/private (plot->dc v) (view->dc (plot->view v)))
+    (define/public (plot->dc v) (view->dc (plot->view v)))
     (define/private (norm->dc v) (view->dc (norm->view v)))
     
     (define: view-x-size : Real  0)

--- a/plot-lib/plot/private/plot3d/plot-area.rkt
+++ b/plot-lib/plot/private/plot3d/plot-area.rkt
@@ -1635,12 +1635,14 @@
 
     (define/public (get-plot-metrics-functions)
       (list (let ([bounds bounds-rect]
-                  [vect : (Option (Immutable-Vector (Immutable-Vector Real Real) (Immutable-Vector Real Real))) #f])
+                  [vect : (Option (Immutable-Vector (Immutable-Vector Real Real) (Immutable-Vector Real Real) (Immutable-Vector Real Real))) #f])
               (λ () (or vect
                         (let ([new (vector-immutable (vector-immutable (assert (ivl-min (vector-ref bounds 0)) real?)
                                                                        (assert (ivl-max (vector-ref bounds 0)) real?))
                                                      (vector-immutable (assert (ivl-min (vector-ref bounds 1)) real?)
-                                                                       (assert (ivl-max (vector-ref bounds 1)) real?)))])
+                                                                       (assert (ivl-max (vector-ref bounds 1)) real?))
+                                                     (vector-immutable (assert (ivl-min (vector-ref bounds 2)) real?)
+                                                                       (assert (ivl-max (vector-ref bounds 2)) real?)))])
                           (set! vect new)
                           new))))
             plot->dc

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -21,6 +21,7 @@
  Legend-Anchor
  Plot-Metrics<%>
  plotpict?
+ PlotPict
  plotpict-bounds
  plotpict-plot->dc)
 

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -18,7 +18,11 @@
  Labels
  Contour-Levels
  Image-File-Format
- Legend-Anchor)
+ Legend-Anchor
+ Plot-Metrics<%>
+ plotpict?
+ plotpict-bounds
+ plotpict-plot->dc)
 
 (require "common/math.rkt")
 

--- a/plot-lib/plot/private/utils-and-no-gui.rkt
+++ b/plot-lib/plot/private/utils-and-no-gui.rkt
@@ -18,12 +18,18 @@
  Labels
  Contour-Levels
  Image-File-Format
- Legend-Anchor
+ Legend-Anchor)
+
+(require "common/plotmetrics.rkt")
+
+(provide
  Plot-Metrics<%>
- plotpict?
- PlotPict
- plotpict-bounds
- plotpict-plot->dc)
+ plot-pict?
+ Plot-Pict
+ plot-pict-bounds
+ plot-pict-plot->dc
+ plot-pict-dc->plot
+ plot-pict-plane-vector)
 
 (require "common/math.rkt")
 

--- a/plot-test/plot/tests/PRs/90.rkt
+++ b/plot-test/plot/tests/PRs/90.rkt
@@ -68,7 +68,9 @@
                                       (send ps plot->dc #(0 0 0))))
             (test-suite "PR90: 3d/snip before resize"
                         (check-equal? (send ps plot->dc plotcoords) coords))
-            (test-suite "PR90: 3d/snip after resize"
+            ;It's uncertain that the sleep/yield will be long enough for the async update to finish
+            ;for now this test is disabled.
+            #;(test-suite "PR90: 3d/snip after resize"
                         (send ps resize 800 800)
                         (sleep/yield .5)
                         (check-within (send ps plot->dc (send ps dc->plot #(200 200)))

--- a/plot-test/plot/tests/PRs/90.rkt
+++ b/plot-test/plot/tests/PRs/90.rkt
@@ -70,9 +70,9 @@
                         (check-equal? (send ps plot->dc plotcoords) coords))
             (test-suite "PR90: 3d/snip after resize"
                         (send ps resize 800 800)
-                        (sleep/yield .1)
+                        (sleep/yield .5)
                         (check-within (send ps plot->dc (send ps dc->plot #(200 200)))
-                                      #(200 200) 5e-14)
+                                      #(200 200) 1e-13)
                         (check-not-equal? (send ps plot->dc plotcoords) coords)))))
    ))
 

--- a/plot-test/plot/tests/PRs/90.rkt
+++ b/plot-test/plot/tests/PRs/90.rkt
@@ -1,0 +1,81 @@
+#lang racket
+(require rackunit
+         racket/draw pict (only-in racket/gui/base sleep/yield)
+         plot (submod plot/private/common/plotmetrics untyped))
+
+; tests for PR#90, https://github.com/racket/plot/pull/90
+; "Plotmetrics: access/calculate data about the plot area"
+
+
+(define pr90-test-suite
+  (make-test-suite
+   "PR#90: plotmetrics"
+   (append
+    (let* ([bm (make-object bitmap% 400 400)]
+           [dc (make-object bitmap-dc% bm)]
+           [pm (plot/dc (polar (λ (x) x)) dc 0 0 400 400)])
+      (list (test-suite "PR90: plot-metrics get-plot-bounds"
+                        (check-within (send pm get-plot-bounds)
+                                      #(#(-3.2883704095701205 6.283185307179586)
+                                        #(-4.8144539337330965 1.81970262809755))
+                                      1e-15))
+            (test-suite "PR90: plot-metrics plot->dc & dc->plot"
+                        (check-within (send pm dc->plot (send pm plot->dc #(0 0)))
+                                      #(0 0) 1e-15))
+            (test-suite "PR90: plot-metrics plane-vector"
+                        (check-equal? (send pm plane-vector)
+                                      #(0 0 1)))))
+    
+    (let ([pmbm (plot3d-bitmap (polar3d (λ (ϕ θ) ϕ)))])
+      (list (test-suite "PR90: bitmap" (check-true (is-a? pmbm bitmap%)))
+            (test-suite "PR90: 3d/bitmap get-plot-bounds"
+                        (check-within (send pmbm get-plot-bounds)
+                                      #(#(-3.287703432872698 6.282003882664296)
+                                        #(-4.812750657123522 1.819088586099858)
+                                        #(-6.283185307179587 6.283185307179587))
+                                      1e-15))
+            (test-suite "PR90: 3d/bitmap plot->dc & dc->plot"
+                        (check-within (send pmbm plot->dc (send pmbm dc->plot #(200 200)))
+                                      #(200 200) 1e-15))
+            (test-suite "PR90: 3d/bitmap plane-vector"
+                        (check-equal? (send pmbm plot->dc (send pmbm plane-vector))
+                                      (send pmbm plot->dc #(0 0 0))))))
+    
+    (let ([pp (plot-pict (function (λ (x) x) 1 2))])
+      (list (test-suite "PR90: plot-pict" (check-true (and (plot-pict? pp) (pict? pp))))
+            (test-suite "PR90: plot-pict get-plot-bounds"
+                        (check-equal? (plot-pict-bounds pp)
+                                      #(#(1 2) #(1 2))))
+            (test-suite "PR90: plot-pict plot->dc & dc->plot"
+                        (check-within ((plot-pict-dc->plot pp) ((plot-pict-plot->dc pp) #(0 0)))
+                                      #(0 0) 1e-15))
+            (test-suite "PR90: plot-pict plane-vector"
+                        (check-equal? (plot-pict-plane-vector pp)
+                                      #(0 0 1)))))
+
+    (let* ([ps (plot3d-snip (surface3d (λ (x y) (+ x y)) 0 1 1 2))]
+           [plotcoords #(1 1 1)]
+           [coords (send ps plot->dc plotcoords)])
+      (list (test-suite "PR90: 3d/snip" (check-true (is-a? ps plot-metrics<%>)))
+            (test-suite "PR90: 3d/snip get-plot-bounds"
+                        (check-equal? (send ps get-plot-bounds)
+                                      #(#(0 1) #(1 2) #(1 3))))
+            (test-suite "PR90: 3d/snip plot->dc & dc->plot"
+                        (check-within (send ps plot->dc (send ps dc->plot #(200 200)))
+                                      #(200 200) 1e-15))
+            (test-suite "PR90: 3d/snip plane-vector"
+                        (check-equal? (send ps plot->dc (send ps plane-vector))
+                                      (send ps plot->dc #(0 0 0))))
+            (test-suite "PR90: 3d/snip before resize"
+                        (check-equal? (send ps plot->dc plotcoords) coords))
+            (test-suite "PR90: 3d/snip after resize"
+                        (send ps resize 800 800)
+                        (sleep/yield .1)
+                        (check-within (send ps plot->dc (send ps dc->plot #(200 200)))
+                                      #(200 200) 5e-14)
+                        (check-not-equal? (send ps plot->dc plotcoords) coords)))))
+   ))
+
+(module+ test
+  (require rackunit/text-ui)
+  (run-tests pr90-test-suite))


### PR DESCRIPTION
Possible implementation for getting plot-metrics from plots. see #83 

#### Currently implemented methods:
- `get-plot-boundaries`: `(-> (Vectorof (Vector Real Real))`  - give min/max x y (z) values
- `plot->dc`: `(-> (Vecorof Real) (Vectorof Real))` - translate plot x y (z) coordinates to dc x y coordinates

#### Possible problems:
- This changes the return type for `plot/dc`, `plot-bitmap`, `plot-snip`, `plot-pict`
- typed-untyped interaction: Except for `plot-pict` the return types are new objects for which no interface or class is defined. There will be no straighforward way to check if the returned objects implement `Plot-Metrics<%>`

#### todo:
- [ ] documentation
- [ ] tests
