### PR TITLE
remove 'untyped-' redirects

### DIFF
--- a/plot-lib/plot/bitmap.rkt
+++ b/plot-lib/plot/bitmap.rkt
@@ -17,7 +17,7 @@
            "private/plot2d/renderer.rkt")
   (provide
    (contract-out
-    [untyped-plot
+    [plot
      (->* [(treeof (or/c renderer2d? nonrenderer?))]
           [#:x-min (or/c real? #f)
            #:x-max (or/c real? #f)
@@ -33,7 +33,7 @@
            #:out-file (or/c path? string? output-port? #f)
            #:out-kind symbol?]
           (is-a?/c bitmap%))]
-    [untyped-plot3d
+    [plot3d
      (->* [(treeof (or/c renderer3d? nonrenderer?))]
           [#:x-min (or/c real? #f)
            #:x-max (or/c real? #f)
@@ -52,15 +52,15 @@
            #:legend-anchor anchor/c
            #:out-file (or/c path? string? output-port? #f)
            #:out-kind symbol?]
-          (is-a?/c bitmap%))]))
-   (define untyped-plot3d plot3d)
-   (define untyped-plot plot))
+          (is-a?/c bitmap%))])))
 
 
 (require (rename-in "private/no-gui/plot-bitmap.rkt"
                     [plot typed-plot]
                     [plot3d typed-plot3d])
-         'untyped)
+         (rename-in (submod "." untyped)
+                    [plot untyped-plot]
+                    [plot3d untyped-plot3d]))
 
 (define-typed/untyped-identifier plot
   typed-plot

--- a/plot-lib/plot/no-gui.rkt
+++ b/plot-lib/plot/no-gui.rkt
@@ -26,7 +26,10 @@
                     [plot/dc     typed-plot/dc]
                     [plot-bitmap typed-plot-bitmap]
                     [plot-pict   typed-plot-pict])
-         "private/no-gui/plot2d-untyped.rkt")
+         (rename-in "private/no-gui/plot2d-untyped.rkt"
+                    [plot/dc untyped-plot/dc]
+                    [plot-bitmap untyped-plot-bitmap]
+                    [plot-pict untyped-plot-pict]))
 
 (define-typed/untyped-identifier plot/dc
   typed-plot/dc

--- a/plot-lib/plot/private/no-gui/plot2d-untyped.rkt
+++ b/plot-lib/plot/private/no-gui/plot2d-untyped.rkt
@@ -12,7 +12,7 @@
 
 (provide
  (contract-out
-  [untyped-plot/dc
+  [plot/dc
    (->* [(treeof (or/c renderer2d? nonrenderer?))
          (is-a?/c dc<%>)
          real?
@@ -29,7 +29,7 @@
          #:aspect-ratio (or/c (and/c rational? positive?) #f)
          #:legend-anchor legend-anchor/c]
         plot-metrics-object/c)]
-   [untyped-plot-bitmap
+   [plot-bitmap
     (->* [(treeof (or/c renderer2d? nonrenderer?))]
          [#:x-min (or/c real? #f)
           #:x-max (or/c real? #f)
@@ -43,7 +43,7 @@
           #:aspect-ratio (or/c (and/c rational? positive?) #f)
           #:legend-anchor legend-anchor/c]
          (and/c (is-a?/c bitmap%) plot-metrics-object/c))]
-    [untyped-plot-pict
+    [plot-pict
      (->* [(treeof (or/c renderer2d? nonrenderer?))]
           [#:x-min (or/c real? #f)
            #:x-max (or/c real? #f)
@@ -58,6 +58,3 @@
            #:legend-anchor legend-anchor/c]
           plot-pict?)]))
 
-(define untyped-plot/dc plot/dc)
-(define untyped-plot-pict plot-pict)
-(define untyped-plot-bitmap plot-bitmap)


### PR DESCRIPTION
Remove extra defines from untyped reprovide modules. These aren't
needed for safety, and I don't think they help much with error
messages & keeping ids distinct either.

(After removing, the `define-typed/untyped-id` in plot work as-is
for Transient. If we kept the defines, transient would need new
identifiers.)