### PR TITLE
Clarify expectations for ticks-format function (#113)

### DIFF
--- a/plot-doc/plot/scribblings/ticks.scrbl
+++ b/plot-doc/plot/scribblings/ticks.scrbl
@@ -606,11 +606,31 @@ Represents a tick with a label.
 }
 
 @defthing[ticks-layout/c contract? #:value (-> real? real? (listof pre-tick?))]{
-The contract for tick layout functions. Note that a layout function returns @racket[pre-tick]s, or unlabeled ticks.
+
+  The contract for tick layout functions in @racket[ticks] structures.  The
+  function receives axis bounds and returns a list of @racket[pre-tick]s to be
+  shown on the axis.
+
+  Note that the layout function returns @racket[pre-tick]s, or unlabeled
+  ticks, and a separate format function is used to produce the labels for the
+  ticks.
+
 }
 
 @defthing[ticks-format/c contract? #:value (-> real? real? (listof pre-tick?) (listof string?))]{
-The contract for tick format functions. A format function receives axis bounds so it can determine how many decimal digits to display (usually by applying @racket[digits-for-range] to the bounds).
+
+  The contract for tick format functions in @racket[ticks] structures.  The
+  format function receives axis bounds and a list of @racket[pre-tick]s and
+  return a label for each @racket[pre-tick] in this list.
+
+  The returned labels should be usually distinct, as the plot library will
+  consider ticks with the same label to be duplicates and collapse them,
+  however, this feature can be used by a custom format function to force
+  removal of some ticks form the plot.
+
+  Axis bounds can be used to determine how many decimal digits to display,
+  usually by applying @racket[digits-for-range] to the bounds.
+
 }
 
 @section[#:tag "invertible"]{Invertible Functions}

--- a/plot-doc/plot/scribblings/ticks.scrbl
+++ b/plot-doc/plot/scribblings/ticks.scrbl
@@ -620,13 +620,13 @@ Represents a tick with a label.
 @defthing[ticks-format/c contract? #:value (-> real? real? (listof pre-tick?) (listof string?))]{
 
   The contract for tick format functions in @racket[ticks] structures.  The
-  format function receives axis bounds and a list of @racket[pre-tick]s and
-  return a label for each @racket[pre-tick] in this list.
+  format function receives axis bounds and a list of @racket[pre-tick]s. It
+  must return a label for each @racket[pre-tick] in this list.
 
   The returned labels should be usually distinct, as the plot library will
-  consider ticks with the same label to be duplicates and collapse them,
-  however, this feature can be used by a custom format function to force
-  removal of some ticks form the plot.
+  consider ticks with labels that are @racket[string=?] to be duplicates and
+  collapse them, however, this feature can be used by a custom format function
+  to force removal of some ticks from the plot.
 
   Axis bounds can be used to determine how many decimal digits to display,
   usually by applying @racket[digits-for-range] to the bounds.

--- a/plot-lib/plot/private/common/ticks.rkt
+++ b/plot-lib/plot/private/common/ticks.rkt
@@ -35,10 +35,16 @@
 
 (:: ticks-generate (-> ticks Real Real (Listof tick)))
 (define (ticks-generate t x-min x-max)
-  (match-define (ticks layout format) t)
+  (match-define (ticks layout fmt) t)
   (define ts (map pre-tick-inexact->exact (layout x-min x-max)))
   (match-define (list (pre-tick #{xs : (Listof Real)} #{majors : (Listof Boolean)}) ...) ts)
-  (map tick xs majors (format x-min x-max ts)))
+  (define labels (fmt x-min x-max ts))
+  (unless (= (length labels) (length ts))
+    (error
+     'ticks-format
+     (format "ticks format function returned bad number of labels, expecting ~a, got ~a"
+             (length ts) (length labels))))
+  (map tick xs majors labels))
 
 (defparam ticks-default-number Positive-Integer 4)
 

--- a/plot-lib/plot/private/common/ticks.rkt
+++ b/plot-lib/plot/private/common/ticks.rkt
@@ -35,15 +35,20 @@
 
 (:: ticks-generate (-> ticks Real Real (Listof tick)))
 (define (ticks-generate t x-min x-max)
-  (match-define (ticks layout fmt) t)
+  (match-define (ticks layout format) t)
   (define ts (map pre-tick-inexact->exact (layout x-min x-max)))
   (match-define (list (pre-tick #{xs : (Listof Real)} #{majors : (Listof Boolean)}) ...) ts)
-  (define labels (fmt x-min x-max ts))
+  (define labels (format x-min x-max ts))
   (unless (= (length labels) (length ts))
-    (error
-     'ticks-format
-     (format "ticks format function returned bad number of labels, expecting ~a, got ~a"
-             (length ts) (length labels))))
+    (raise-arguments-error
+     'ticks-generate
+     "ticks-format must return one label for each pre-tick"
+     "num. expected" (length ts)
+     "num. returned" (length labels)
+     "pre-ticks" ts
+     "labels" labels
+     "ticks-layout" layout
+     "ticks-format" format))
   (map tick xs majors labels))
 
 (defparam ticks-default-number Positive-Integer 4)


### PR DESCRIPTION
Add a check that the ticks format function returns the same number of labels as input pre-tick elements.  Also updated the documentation to better explain what the function needs to return.