### PR TITLE
Remove unused code in glyph drawing code

### DIFF
--- a/plot-lib/plot/private/common/plot-device.rkt
+++ b/plot-lib/plot/private/common/plot-device.rkt
@@ -546,9 +546,6 @@
              (define r (* 1/2 size))
              (define line-sym
                (cond [(hash-has-key? full-glyph-hash real-sym)
-                      (when (eq? pen-color brush-color)
-                        (set-pen pen-color 1 'transparent)
-                        (set-brush brush-color 'solid))
                       (hash-ref full-glyph-hash real-sym)]
                      [else  (set-brush brush-color 'transparent)
                             real-sym]))


### PR DESCRIPTION
The original intent of the `when` block was to remove the line around the glyph when the line and fill color were the same. However, the `eq?` test was always false in Typed Racket, so the code never executed.

The `eq?` test is now fixed in
https://github.com/racket/typed-racket/pull/1358, but as a result, the visual layout of plots would change, making glyphs smaller, since the outline is not drawn anymore.

To keep the backwards compatibility of the plot look-and-feel, the entire `when` block was removed.